### PR TITLE
fix(get-transactions): exclude transfers from uncategorizedOnly results

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,7 +99,7 @@ npm start            # tsx src/index.ts (dev mode)
 ## Tool Features
 ### get-transactions
 - Filters: date range, amount, category, payee, uncategorizedOnly, limit
-- `uncategorizedOnly: true` - Returns only transactions without category assignment (both `category` and `category_name` are null/undefined)
+- `uncategorizedOnly: true` - Returns only transactions without category assignment (both `category` and `category_name` are null/undefined). Transfers (`transfer_id` set) are excluded since they cannot be categorized.
 - Filters are composable - can combine uncategorizedOnly with other filters
 
 ### Testing Guidelines

--- a/src/tools/get-transactions/index.test.ts
+++ b/src/tools/get-transactions/index.test.ts
@@ -150,6 +150,71 @@ describe('get-transactions tool', () => {
       expect(result.content[0].text).not.toContain('tx3');
       expect(result.content[0].text).toContain('Matching Transactions: 1/4');
     });
+
+    it('should exclude transfers from uncategorizedOnly results', async () => {
+      const withTransfers: Transaction[] = [
+        {
+          id: 'tx-uncat',
+          account: 'account-1',
+          date: '2025-12-01',
+          amount: 5000,
+          payee_name: 'Unknown Store',
+        },
+        {
+          id: 'tx-transfer-out',
+          account: 'account-1',
+          date: '2025-12-02',
+          amount: -20000,
+          payee_name: 'Credit Card',
+          transfer_id: 'tx-transfer-in',
+        },
+        {
+          id: 'tx-transfer-in',
+          account: 'account-2',
+          date: '2025-12-02',
+          amount: 20000,
+          payee_name: 'Checking',
+          transfer_id: 'tx-transfer-out',
+        },
+      ];
+      mockFetch.mockResolvedValue(withTransfers);
+
+      const args: GetTransactionsArgs = {
+        accountId: 'account-1',
+        uncategorizedOnly: true,
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('tx-uncat');
+      expect(result.content[0].text).not.toContain('tx-transfer-out');
+      expect(result.content[0].text).not.toContain('tx-transfer-in');
+      expect(result.content[0].text).toContain('Matching Transactions: 1/3');
+    });
+
+    it('should include transfers when uncategorizedOnly is not set', async () => {
+      const withTransfers: Transaction[] = [
+        {
+          id: 'tx-transfer-out',
+          account: 'account-1',
+          date: '2025-12-02',
+          amount: -20000,
+          payee_name: 'Credit Card',
+          transfer_id: 'tx-transfer-in',
+        },
+      ];
+      mockFetch.mockResolvedValue(withTransfers);
+
+      const args: GetTransactionsArgs = {
+        accountId: 'account-1',
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('tx-transfer-out');
+    });
   });
 
   describe('handler - edge cases', () => {

--- a/src/tools/get-transactions/index.ts
+++ b/src/tools/get-transactions/index.ts
@@ -42,8 +42,6 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
       filtered = filtered.filter((t) => (t.payee_name || '').toLowerCase().includes(lowerPayee));
     }
     if (uncategorizedOnly) {
-      // # Reason: Transfers (transactions with transfer_id) are handled by Actual's transfer mechanic,
-      // not by category assignment, so they should not appear in "uncategorized" results.
       filtered = filtered.filter((t) => !t.category && !t.category_name && !t.transfer_id);
     }
     if (limit && filtered.length > limit) {

--- a/src/tools/get-transactions/index.ts
+++ b/src/tools/get-transactions/index.ts
@@ -42,7 +42,9 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
       filtered = filtered.filter((t) => (t.payee_name || '').toLowerCase().includes(lowerPayee));
     }
     if (uncategorizedOnly) {
-      filtered = filtered.filter((t) => !t.category && !t.category_name);
+      // # Reason: Transfers (transactions with transfer_id) are handled by Actual's transfer mechanic,
+      // not by category assignment, so they should not appear in "uncategorized" results.
+      filtered = filtered.filter((t) => !t.category && !t.category_name && !t.transfer_id);
     }
     if (limit && filtered.length > limit) {
       filtered = filtered.slice(0, limit);

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,7 @@ export const GetTransactionsArgsSchema = z.object({
   uncategorizedOnly: z
     .boolean()
     .optional()
-    .describe(
-      'If true, return only transactions that lack a category. Transfers between own accounts are excluded since they are handled by the transfer mechanic and cannot be categorized.'
-    ),
+    .describe('If true, return only transactions that lack a category. Transfers are excluded.'),
   limit: z.number().optional(),
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,12 @@ export const GetTransactionsArgsSchema = z.object({
   maxAmount: z.number().optional(),
   categoryName: z.string().optional(),
   payeeName: z.string().optional(),
-  uncategorizedOnly: z.boolean().optional(),
+  uncategorizedOnly: z
+    .boolean()
+    .optional()
+    .describe(
+      'If true, return only transactions that lack a category. Transfers between own accounts are excluded since they are handled by the transfer mechanic and cannot be categorized.'
+    ),
   limit: z.number().optional(),
 });
 


### PR DESCRIPTION
Transfer transactions (legs with transfer_id set) are handled by Actual's
transfer mechanic, not by category assignment, so they should not appear
in "uncategorized" results. Closes #27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `uncategorizedOnly` filter now correctly excludes transfers between own accounts in addition to transactions lacking a category.

* **Documentation**
  * Updated parameter documentation to clarify the uncategorized filter behavior.

* **Tests**
  * Extended test coverage for uncategorized filtering scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baruchiro/actual-mcp/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->