### PR TITLE
fix(errors): add correlation id to tool error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,13 @@ Since MCP servers communicate over stdio, debugging can be challenging. You can 
 npx @modelcontextprotocol/inspector node build/index.js
 ```
 
+When a tool call fails, the server returns a structured error instead of crashing. The
+error text includes the failing tool name, a stable machine-readable code (e.g.
+`auth_required`, `unknown_tool`), and a correlation id (`ref: <uuid>`). The same
+correlation id is also exposed in the response `_meta` (`correlationId`) and written to
+the server logs, so a reported `ref:` can be traced directly to its server-side stack
+trace without needing container access.
+
 ## Project Structure
 
 - `index.ts` - Main server implementation

--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -1,7 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { error, errorFromCatch, normalizeError, success, successWithJson } from './response.js';
 
+const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+
 describe('response utilities', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Reason: error()/errorFromCatch() log to the server console by design;
+    // silence (and capture) it here so test output stays clean.
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
   describe('success', () => {
     it('returns a text content result', () => {
       const result = success('hello');
@@ -21,14 +35,36 @@ describe('response utilities', () => {
     it('marks result as error and prefixes with "Error"', () => {
       const result = error('boom');
       expect(result.isError).toBe(true);
-      expect((result.content[0] as { text: string }).text).toBe('Error: boom');
-      expect(result._meta).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toMatch(/^Error \(ref: [0-9a-f-]+\): boom$/);
+      expect(result._meta?.correlationId).toMatch(UUID);
     });
 
     it('includes tool name and code when provided', () => {
       const result = error('boom', { toolName: 'get-accounts', code: 'budget_not_loaded' });
-      expect((result.content[0] as { text: string }).text).toBe('Error in get-accounts [budget_not_loaded]: boom');
-      expect(result._meta).toEqual({ code: 'budget_not_loaded', tool: 'get-accounts' });
+      expect((result.content[0] as { text: string }).text).toMatch(
+        /^Error in get-accounts \[budget_not_loaded\] \(ref: [0-9a-f-]+\): boom$/
+      );
+      expect(result._meta).toMatchObject({ code: 'budget_not_loaded', tool: 'get-accounts' });
+      expect(result._meta?.correlationId).toMatch(UUID);
+    });
+
+    it('generates a unique correlation id for each error', () => {
+      const a = error('boom');
+      const b = error('boom');
+      expect(a._meta?.correlationId).not.toBe(b._meta?.correlationId);
+    });
+
+    it('uses the same correlation id in the text and _meta', () => {
+      const result = error('boom', { toolName: 'get-accounts' });
+      const id = result._meta?.correlationId as string;
+      expect((result.content[0] as { text: string }).text).toContain(`ref: ${id}`);
+    });
+
+    it('logs the correlation id and message to the server console', () => {
+      const result = error('boom', { toolName: 'get-accounts', code: 'auth_required' });
+      const id = result._meta?.correlationId as string;
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(id));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('boom'));
     });
   });
 
@@ -81,8 +117,14 @@ describe('response utilities', () => {
   describe('errorFromCatch', () => {
     it('produces a useful message for Error instances', () => {
       const result = errorFromCatch(new Error('boom'));
-      expect((result.content[0] as { text: string }).text).toBe('Error: boom');
+      expect((result.content[0] as { text: string }).text).toMatch(/^Error \(ref: [0-9a-f-]+\): boom$/);
       expect(result.isError).toBe(true);
+    });
+
+    it('logs the stack under the same correlation id', () => {
+      const result = errorFromCatch(new Error('boom'));
+      const id = result._meta?.correlationId as string;
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`[${id}] stack:`));
     });
 
     it('never produces "[object Object]" for plain object rejections', () => {
@@ -101,14 +143,18 @@ describe('response utilities', () => {
 
     it('attaches tool name from context', () => {
       const result = errorFromCatch(new Error('boom'), { toolName: 'get-accounts' });
-      expect((result.content[0] as { text: string }).text).toBe('Error in get-accounts: boom');
-      expect(result._meta).toEqual({ tool: 'get-accounts' });
+      expect((result.content[0] as { text: string }).text).toMatch(/^Error in get-accounts \(ref: [0-9a-f-]+\): boom$/);
+      expect(result._meta).toMatchObject({ tool: 'get-accounts' });
+      expect(result._meta?.correlationId).toMatch(UUID);
     });
 
     it('lifts the code from the thrown object into the response', () => {
       const result = errorFromCatch({ message: 'auth failed', code: 'auth_required' }, { toolName: 'get-accounts' });
-      expect((result.content[0] as { text: string }).text).toBe('Error in get-accounts [auth_required]: auth failed');
-      expect(result._meta).toEqual({ code: 'auth_required', tool: 'get-accounts' });
+      expect((result.content[0] as { text: string }).text).toMatch(
+        /^Error in get-accounts \[auth_required\] \(ref: [0-9a-f-]+\): auth failed$/
+      );
+      expect(result._meta).toMatchObject({ code: 'auth_required', tool: 'get-accounts' });
+      expect(result._meta?.correlationId).toMatch(UUID);
     });
   });
 });

--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -112,6 +112,11 @@ describe('response utilities', () => {
       expect(normalizeError({ reason: 'rejected' })).toMatchObject({ message: 'rejected' });
       expect(normalizeError({ error: 'broke' })).toMatchObject({ message: 'broke' });
     });
+
+    it('preserves name and stack from non-Error objects', () => {
+      const result = normalizeError({ message: 'boom', name: 'CustomError', stack: 'CustomError: boom\n  at x' });
+      expect(result).toMatchObject({ message: 'boom', name: 'CustomError', stack: 'CustomError: boom\n  at x' });
+    });
   });
 
   describe('errorFromCatch', () => {
@@ -125,6 +130,12 @@ describe('response utilities', () => {
       const result = errorFromCatch(new Error('boom'));
       const id = result._meta?.correlationId as string;
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`[${id}] stack:`));
+    });
+
+    it('logs the stack from a thrown plain object under the same correlation id', () => {
+      const result = errorFromCatch({ message: 'boom', stack: 'CustomError: boom\n  at x' });
+      const id = result._meta?.correlationId as string;
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`[${id}] stack: CustomError: boom`));
     });
 
     it('never produces "[object Object]" for plain object rejections', () => {

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -134,20 +134,28 @@ export function normalizeError(err: unknown): NormalizedError {
     const messageCandidates = [record.message, record.error, record.reason, record.description, record.detail];
     const message = messageCandidates.find((value): value is string => typeof value === 'string' && value.length > 0);
     const code = typeof record.code === 'string' ? record.code : undefined;
+    // Reason: preserve name/stack when a non-Error object is thrown (e.g.
+    // a serialized error), so errorFromCatch() can still log the stack under
+    // the same correlation id and keep the traceability path intact.
+    const extras = {
+      ...(typeof record.name === 'string' ? { name: record.name } : {}),
+      ...(typeof record.stack === 'string' ? { stack: record.stack } : {}),
+      ...(code ? { code } : {}),
+    };
     if (message) {
-      return { message, ...(code ? { code } : {}) };
+      return { message, ...extras };
     }
     // No usable string field — fall through to JSON serialization so the
     // client at least sees the shape of the object instead of "[object Object]".
     try {
       const serialized = JSON.stringify(err);
       if (serialized && serialized !== '{}') {
-        return { message: serialized, ...(code ? { code } : {}) };
+        return { message: serialized, ...extras };
       }
     } catch {
       // circular or otherwise unserializable
     }
-    return { message: 'Unknown error (non-serializable object thrown)', ...(code ? { code } : {}) };
+    return { message: 'Unknown error (non-serializable object thrown)', ...extras };
   }
 
   return { message: String(err) };

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -2,6 +2,7 @@
 // RESPONSE UTILITIES
 // ----------------------------
 
+import { randomUUID } from 'node:crypto';
 import { CallToolResult, TextContent, ImageContent, AudioContent } from '@modelcontextprotocol/sdk/types.js';
 
 /**
@@ -84,19 +85,24 @@ export function successWithJson<T>(data: T): CallToolResult {
  * @returns An error response object
  */
 export function error(message: string, context: ErrorContext = {}): CallToolResult {
+  // Reason: every failure gets a correlation id that is both returned to the
+  // client (as a human-quotable `ref:` in the text and as `_meta.correlationId`)
+  // and logged server-side under the same id. This lets a user report a failure
+  // by its ref and a maintainer grep the matching log line, without the user
+  // needing container/log access.
+  const correlationId = randomUUID();
   const prefix = context.toolName ? `Error in ${context.toolName}` : 'Error';
   const codeSuffix = context.code ? ` [${context.code}]` : '';
-  const result: CallToolResult = {
+  console.error(`[${correlationId}] ${prefix}${codeSuffix}: ${message}`);
+  return {
     isError: true,
-    content: [{ type: 'text', text: `${prefix}${codeSuffix}: ${message}` }],
-  };
-  if (context.code || context.toolName) {
-    result._meta = {
+    content: [{ type: 'text', text: `${prefix}${codeSuffix} (ref: ${correlationId}): ${message}` }],
+    _meta: {
+      correlationId,
       ...(context.code ? { code: context.code } : {}),
       ...(context.toolName ? { tool: context.toolName } : {}),
-    };
-  }
-  return result;
+    },
+  };
 }
 
 /**
@@ -158,8 +164,15 @@ export function normalizeError(err: unknown): NormalizedError {
  */
 export function errorFromCatch(err: unknown, context: ErrorContext = {}): CallToolResult {
   const normalized = normalizeError(err);
-  return error(normalized.message, {
+  const result = error(normalized.message, {
     ...context,
     code: context.code ?? normalized.code,
   });
+  if (normalized.stack) {
+    // Reason: keep the full stack out of the client response but log it under
+    // the same correlation id, so the user-facing ref traces back to the trace.
+    const correlationId = (result._meta as { correlationId?: string } | undefined)?.correlationId;
+    console.error(`[${correlationId ?? 'unknown'}] stack: ${normalized.stack}`);
+  }
+  return result;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,13 +5,13 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
-    include: ['src/core/**/*.test.ts', 'src/tools/**/*.test.ts'],
+    include: ['src/**/*.test.ts'],
     globals: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],
-      include: ['src/core/**/*.ts', 'src/tools/**/*.ts'],
-      exclude: ['src/core/**/*.test.ts', 'src/tools/**/*.test.ts', 'src/core/types/domain.ts'],
+      include: ['src/core/**/*.ts', 'src/tools/**/*.ts', 'src/utils/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/core/types/domain.ts'],
     },
     alias: {
       '^(\\.{1,2}/.*)\\.js$': '$1', // Handle .js imports in TypeScript


### PR DESCRIPTION
## Summary

This PR adds correlation IDs to all error responses, enabling better server-side debugging and error tracing. Each error now includes a unique UUID that appears in the error message, response metadata, and server logs, allowing users to report failures by reference and maintainers to trace them directly to stack traces.

## Key Changes

- **Correlation ID generation**: Every error now gets a unique UUID via `randomUUID()` from Node's crypto module
- **Error message format**: Updated to include `(ref: <uuid>)` in the error text for user-facing reference
- **Response metadata**: Added `correlationId` to `_meta` object on all error responses
- **Server-side logging**: Errors and their stack traces are now logged with the correlation ID for server-side tracing
- **Test coverage**: Added comprehensive tests for correlation ID generation, uniqueness, consistency, and logging behavior
- **Test infrastructure**: Added `beforeEach`/`afterEach` hooks to mock `console.error` and keep test output clean
- **Vitest config**: Expanded test coverage to include `src/utils/**/*.ts` files
- **Documentation**: Updated README with explanation of the error correlation system

## Implementation Details

- Correlation IDs are generated once per error call and used consistently across the error text, metadata, and logs
- Stack traces from caught errors are logged separately under the same correlation ID but excluded from the client response
- The logging format uses `[<correlationId>]` prefix for easy grepping in server logs
- All existing error handling paths (`error()` and `errorFromCatch()`) now include correlation IDs
- Tests verify that each error gets a unique ID and that the ID appears in both the response and logs

https://claude.ai/code/session_01RFhFKaEazwuode3BLkNfaA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool call failures now return structured error responses instead of crashes, with stable machine-readable error codes and unique correlation IDs.
  * Correlation IDs are included in error responses and server logs for improved traceability and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->