### PR TITLE
chore(ci): upgrade actions to latest major versions for Node.js 24

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -53,7 +53,7 @@ jobs:
             org.opencontainers.image.vendor=${{ github.repository_owner }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Only push if not a PR from a fork (forks don't have package write permission)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-reports
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download coverage reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-reports
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves Node.js 20 deprecation warnings flagged on the release-please
workflow. Upgrades all third-party actions across the four pipelines to
their latest major versions so every step runs on the Node.js 24 runtime.

- googleapis/release-please-action v4 -> v5 (explicit Node 20 warning)
- actions/upload-artifact v4 -> v7
- actions/download-artifact v4 -> v8
- docker/setup-buildx-action v3 -> v4
- docker/login-action v3 -> v4
- docker/metadata-action v5 -> v6
- docker/build-push-action v6 -> v7

actions/checkout@v6 and actions/setup-node@v6 are already on their
latest major versions; davelosert/vitest-coverage-report-action@v2 is
also already at its latest major.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use newer versions of GitHub Actions for improved build, testing, and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->