### PR TITLE
feat: port upstream stability fixes for concurrent connections and API lifecycle

### DIFF
--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -56,8 +56,8 @@ describe('actual-api init/shutdown stability (#96)', () => {
   it('serializes concurrent init calls so init() runs only once (edge case)', async () => {
     const { initActualApi } = await loadModule();
 
-    // Make init() pause so both callers overlap; without `initializing = true`
-    // being set before the await, both would race into api.init().
+    // Make init() pause so both callers overlap; they must share the single
+    // memoized init promise rather than each racing into api.init().
     let resolveInit: () => void = () => {};
     mockApi.init.mockImplementationOnce(
       () =>
@@ -90,5 +90,18 @@ describe('actual-api init/shutdown stability (#96)', () => {
     mockApi.shutdown.mockClear();
     await shutdownActualApi();
     expect(mockApi.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('clears the memoized promise on failure so a later call retries (failure case)', async () => {
+    const { initActualApi } = await loadModule();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockApi.init.mockRejectedValueOnce(new Error('init failed'));
+
+    // First attempt rejects...
+    await expect(initActualApi()).rejects.toThrow('init failed');
+    // ...and a later call retries instead of reusing the failed promise.
+    await expect(initActualApi()).resolves.toBeUndefined();
+    expect(mockApi.init).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -104,4 +104,28 @@ describe('actual-api init/shutdown stability (#96)', () => {
     await expect(initActualApi()).resolves.toBeUndefined();
     expect(mockApi.init).toHaveBeenCalledTimes(2);
   });
+
+  it('waits for an in-flight init to settle before shutting down (edge case)', async () => {
+    const { initActualApi, shutdownActualApi } = await loadModule();
+
+    let resolveInit: () => void = () => {};
+    mockApi.init.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInit = resolve;
+        })
+    );
+
+    const initCall = initActualApi();
+    const shutdownCall = shutdownActualApi();
+
+    // Init is still in progress, so shutdown must not call api.shutdown() yet —
+    // doing so would race api.init() against api.shutdown().
+    await Promise.resolve();
+    expect(mockApi.shutdown).not.toHaveBeenCalled();
+
+    resolveInit();
+    await Promise.all([initCall, shutdownCall]);
+    expect(mockApi.shutdown).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the Actual Budget API default export and fs so we never touch a real budget.
+const mockApi = {
+  init: vi.fn(),
+  getBudgets: vi.fn(),
+  downloadBudget: vi.fn(),
+  shutdown: vi.fn(),
+};
+
+vi.mock('@actual-app/api', () => ({
+  default: mockApi,
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(() => true),
+    mkdirSync: vi.fn(),
+  },
+  existsSync: vi.fn(() => true),
+  mkdirSync: vi.fn(),
+}));
+
+/**
+ * Load a fresh copy of the module so the internal `initialized`/`initializing`
+ * state does not leak between tests.
+ */
+async function loadModule(): Promise<typeof import('./actual-api.js')> {
+  vi.resetModules();
+  return import('./actual-api.js');
+}
+
+describe('actual-api init/shutdown stability (#96)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.getBudgets.mockResolvedValue([{ id: 'budget-1', cloudFileId: 'budget-1' }]);
+    mockApi.init.mockResolvedValue(undefined);
+    mockApi.downloadBudget.mockResolvedValue(undefined);
+    mockApi.shutdown.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes the API once (happy path)', async () => {
+    const { initActualApi } = await loadModule();
+
+    await initActualApi();
+    await initActualApi(); // already initialized -> no second init
+
+    expect(mockApi.init).toHaveBeenCalledTimes(1);
+    expect(mockApi.downloadBudget).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes concurrent init calls so init() runs only once (edge case)', async () => {
+    const { initActualApi } = await loadModule();
+
+    // Make init() pause so both callers overlap; without `initializing = true`
+    // being set before the await, both would race into api.init().
+    let resolveInit: () => void = () => {};
+    mockApi.init.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInit = resolve;
+        })
+    );
+
+    const first = initActualApi();
+    const second = initActualApi();
+
+    resolveInit();
+    await Promise.all([first, second]);
+
+    expect(mockApi.init).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows shutdown errors and still resets state (failure case)', async () => {
+    const { initActualApi, shutdownActualApi } = await loadModule();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await initActualApi();
+    mockApi.shutdown.mockRejectedValueOnce(new Error('boom'));
+
+    // Must not throw even though api.shutdown() rejected.
+    await expect(shutdownActualApi()).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalled();
+
+    // State was reset, so a subsequent shutdown is a no-op (no extra api call).
+    mockApi.shutdown.mockClear();
+    await shutdownActualApi();
+    expect(mockApi.shutdown).not.toHaveBeenCalled();
+  });
+});

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -13,15 +13,13 @@ import { RuleEntity, TransactionEntity } from '@actual-app/api/@types/loot-core/
 
 const DEFAULT_DATA_DIR: string = path.resolve(os.homedir() || '.', '.actual');
 
-// Shared init promise: concurrent callers await the same initialization. Cleared
-// on failure (to allow retry) and on shutdown.
 let initPromise: Promise<void> | null = null;
 
 export function initActualApi(): Promise<void> {
   if (!initPromise) {
     initPromise = loadBudget();
     initPromise.catch(() => {
-      initPromise = null; // allow retry after a failed init
+      initPromise = null;
     });
   }
   return initPromise;
@@ -63,7 +61,7 @@ export async function shutdownActualApi(): Promise<void> {
   if (!pending) return;
   initPromise = null;
   try {
-    await pending; // let any in-flight init finish so init/shutdown don't race
+    await pending;
   } catch {
     return;
   }

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -79,8 +79,17 @@ async function loadBudget(): Promise<void> {
  * Shutdown the Actual Budget API.
  */
 export async function shutdownActualApi(): Promise<void> {
-  if (!initPromise) return;
+  const pending = initPromise;
+  if (!pending) return;
   initPromise = null;
+  try {
+    // Reason: wait for any in-flight init to settle so we never call api.init()
+    // and api.shutdown() concurrently. A failed init means there's nothing to
+    // shut down.
+    await pending;
+  } catch {
+    return;
+  }
   try {
     await api.shutdown();
   } catch (err) {

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -32,6 +32,10 @@ export async function initActualApi(): Promise<void> {
     return;
   }
 
+  // Reason: mark initialization as in-progress before any await so concurrent
+  // callers actually hit the wait-loop above instead of racing into init().
+  initializing = true;
+  initializationError = null;
   try {
     console.error('Initializing Actual Budget API...');
     const dataDir = process.env.ACTUAL_DATA_DIR || DEFAULT_DATA_DIR;
@@ -77,8 +81,13 @@ export async function initActualApi(): Promise<void> {
  */
 export async function shutdownActualApi(): Promise<void> {
   if (!initialized) return;
-  await api.shutdown();
-  initialized = false;
+  try {
+    await api.shutdown();
+  } catch (err) {
+    console.error('Error shutting down Actual Budget API:', err);
+  } finally {
+    initialized = false;
+  }
 }
 
 // ----------------------------

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -13,80 +13,78 @@ import { RuleEntity, TransactionEntity } from '@actual-app/api/@types/loot-core/
 
 const DEFAULT_DATA_DIR: string = path.resolve(os.homedir() || '.', '.actual');
 
-// API initialization state
-let initialized = false;
-let initializing = false;
-let initializationError: Error | null = null;
+// API initialization state. A single in-flight/resolved init promise is shared
+// by every caller, so concurrent calls await the same initialization instead of
+// racing into api.init(). It is cleared on failure (so a later call can retry)
+// and on shutdown.
+let initPromise: Promise<void> | null = null;
 
 /**
- * Initialize the Actual Budget API
+ * Initialize the Actual Budget API.
+ *
+ * Concurrent callers all await the same memoized initialization promise. The
+ * cached promise is cleared if initialization fails, so a later call can retry.
+ *
+ * @returns A promise that resolves once the API is initialized and a budget is loaded.
  */
-export async function initActualApi(): Promise<void> {
-  if (initialized) return;
-  if (initializing) {
-    // Wait for initialization to complete if already in progress
-    while (initializing) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    if (initializationError) throw initializationError;
-    return;
-  }
-
-  // Reason: mark initialization as in-progress before any await so concurrent
-  // callers actually hit the wait-loop above instead of racing into init().
-  initializing = true;
-  initializationError = null;
-  try {
-    console.error('Initializing Actual Budget API...');
-    const dataDir = process.env.ACTUAL_DATA_DIR || DEFAULT_DATA_DIR;
-    if (!fs.existsSync(dataDir)) {
-      fs.mkdirSync(dataDir, { recursive: true });
-    }
-    await api.init({
-      dataDir,
-      serverURL: process.env.ACTUAL_SERVER_URL,
-      password: process.env.ACTUAL_PASSWORD,
+export function initActualApi(): Promise<void> {
+  if (!initPromise) {
+    initPromise = loadBudget();
+    // Reason: drop the cached promise on failure so a later call can retry init.
+    initPromise.catch(() => {
+      initPromise = null;
     });
-
-    const budgets: BudgetFile[] = await api.getBudgets();
-    if (!budgets || budgets.length === 0) {
-      throw new Error('No budgets found. Please create a budget in Actual first.');
-    }
-
-    // Use specified budget or the first one
-    const budgetId: string = process.env.ACTUAL_BUDGET_SYNC_ID || budgets[0].cloudFileId || budgets[0].id || '';
-    console.error(`Loading budget: ${budgetId}`);
-    await api.downloadBudget(
-      budgetId,
-      process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD
-        ? {
-            password: process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD,
-          }
-        : undefined
-    );
-
-    initialized = true;
-    console.error('Actual Budget API initialized successfully');
-  } catch (error) {
-    console.error('Failed to initialize Actual Budget API:', error);
-    initializationError = error instanceof Error ? error : new Error(String(error));
-    throw initializationError;
-  } finally {
-    initializing = false;
   }
+  return initPromise;
 }
 
 /**
- * Shutdown the Actual Budget API
+ * Perform the one-time API init and budget download.
+ *
+ * Internal: callers should use {@link initActualApi}, which memoizes this.
+ */
+async function loadBudget(): Promise<void> {
+  console.error('Initializing Actual Budget API...');
+  const dataDir = process.env.ACTUAL_DATA_DIR || DEFAULT_DATA_DIR;
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+  await api.init({
+    dataDir,
+    serverURL: process.env.ACTUAL_SERVER_URL,
+    password: process.env.ACTUAL_PASSWORD,
+  });
+
+  const budgets: BudgetFile[] = await api.getBudgets();
+  if (!budgets || budgets.length === 0) {
+    throw new Error('No budgets found. Please create a budget in Actual first.');
+  }
+
+  // Use specified budget or the first one
+  const budgetId: string = process.env.ACTUAL_BUDGET_SYNC_ID || budgets[0].cloudFileId || budgets[0].id || '';
+  console.error(`Loading budget: ${budgetId}`);
+  await api.downloadBudget(
+    budgetId,
+    process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD
+      ? {
+          password: process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD,
+        }
+      : undefined
+  );
+
+  console.error('Actual Budget API initialized successfully');
+}
+
+/**
+ * Shutdown the Actual Budget API.
  */
 export async function shutdownActualApi(): Promise<void> {
-  if (!initialized) return;
+  if (!initPromise) return;
+  initPromise = null;
   try {
     await api.shutdown();
   } catch (err) {
     console.error('Error shutting down Actual Budget API:', err);
-  } finally {
-    initialized = false;
   }
 }
 

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -13,36 +13,20 @@ import { RuleEntity, TransactionEntity } from '@actual-app/api/@types/loot-core/
 
 const DEFAULT_DATA_DIR: string = path.resolve(os.homedir() || '.', '.actual');
 
-// API initialization state. A single in-flight/resolved init promise is shared
-// by every caller, so concurrent calls await the same initialization instead of
-// racing into api.init(). It is cleared on failure (so a later call can retry)
-// and on shutdown.
+// Shared init promise: concurrent callers await the same initialization. Cleared
+// on failure (to allow retry) and on shutdown.
 let initPromise: Promise<void> | null = null;
 
-/**
- * Initialize the Actual Budget API.
- *
- * Concurrent callers all await the same memoized initialization promise. The
- * cached promise is cleared if initialization fails, so a later call can retry.
- *
- * @returns A promise that resolves once the API is initialized and a budget is loaded.
- */
 export function initActualApi(): Promise<void> {
   if (!initPromise) {
     initPromise = loadBudget();
-    // Reason: drop the cached promise on failure so a later call can retry init.
     initPromise.catch(() => {
-      initPromise = null;
+      initPromise = null; // allow retry after a failed init
     });
   }
   return initPromise;
 }
 
-/**
- * Perform the one-time API init and budget download.
- *
- * Internal: callers should use {@link initActualApi}, which memoizes this.
- */
 async function loadBudget(): Promise<void> {
   console.error('Initializing Actual Budget API...');
   const dataDir = process.env.ACTUAL_DATA_DIR || DEFAULT_DATA_DIR;
@@ -60,7 +44,6 @@ async function loadBudget(): Promise<void> {
     throw new Error('No budgets found. Please create a budget in Actual first.');
   }
 
-  // Use specified budget or the first one
   const budgetId: string = process.env.ACTUAL_BUDGET_SYNC_ID || budgets[0].cloudFileId || budgets[0].id || '';
   console.error(`Loading budget: ${budgetId}`);
   await api.downloadBudget(
@@ -75,18 +58,12 @@ async function loadBudget(): Promise<void> {
   console.error('Actual Budget API initialized successfully');
 }
 
-/**
- * Shutdown the Actual Budget API.
- */
 export async function shutdownActualApi(): Promise<void> {
   const pending = initPromise;
   if (!pending) return;
   initPromise = null;
   try {
-    // Reason: wait for any in-flight init to settle so we never call api.init()
-    // and api.shutdown() concurrently. A failed init means there's nothing to
-    // shut down.
-    await pending;
+    await pending; // let any in-flight init finish so init/shutdown don't race
   } catch {
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,28 +20,11 @@ import { randomUUID } from 'node:crypto';
 import { parseArgs } from 'node:util';
 import { initActualApi, shutdownActualApi } from './actual-api.js';
 import { fetchAllAccounts } from './core/data/fetch-accounts.js';
-import { setupPrompts } from './prompts.js';
-import { setupResources } from './resources.js';
-import { setupTools } from './tools/index.js';
-import { SetLevelRequestSchema, isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createServer } from './server.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
-dotenv.config({ path: '.env' });
-
-// Initialize the MCP server
-const server = new Server(
-  {
-    name: 'Actual Budget',
-    version: '1.0.0',
-  },
-  {
-    capabilities: {
-      resources: {},
-      tools: {},
-      prompts: {},
-      logging: {},
-    },
-  }
-);
+// Reason: dotenv@17 prints to stdout by default, which corrupts MCP stdio JSON parsing.
+dotenv.config({ path: '.env', quiet: true } as Parameters<typeof dotenv.config>[0]);
 
 // Argument parsing
 const {
@@ -178,16 +161,18 @@ async function main(): Promise<void> {
   if (useSse) {
     const app = express();
     app.use(express.json());
-    let transport: SSEServerTransport | null = null;
 
     // Log bearer auth status
     if (enableBearer) {
-      console.error('Bearer authentication enabled for SSE endpoints');
+      process.stderr.write('Bearer authentication enabled for SSE endpoints\n');
     } else {
-      console.error('Bearer authentication disabled - endpoints are public');
+      process.stderr.write('Bearer authentication disabled - endpoints are public\n');
     }
 
-    const streamableHttpTransports = new Map<string, StreamableHTTPServerTransport>();
+    // Reason: each connection/session gets its own Server + transport so concurrent
+    // clients can't overwrite each other's transports or logging state (#137).
+    const legacySseConnections = new Map<string, { server: Server; transport: SSEServerTransport }>();
+    const streamableSessions = new Map<string, { server: Server; transport: StreamableHTTPServerTransport }>();
 
     const parseSessionHeader = (value: string | string[] | undefined): string | undefined => {
       if (!value) {
@@ -203,14 +188,19 @@ async function main(): Promise<void> {
       res.status(404).json({ error: 'OAuth metadata not configured for this server' });
     });
 
-    const handleLegacySse = (req: Request, res: Response): void => {
-      transport = new SSEServerTransport('/messages', res);
-      server.connect(transport).then(() => {
-        console.log = (message: string) => server.sendLoggingMessage({ level: 'info', message });
+    const handleLegacySse = (_req: Request, res: Response): void => {
+      const connectionId = randomUUID();
+      const connServer = createServer({ enableWrite: !!enableWrite });
+      const sseTransport = new SSEServerTransport(`/messages?connectionId=${connectionId}`, res);
+      legacySseConnections.set(connectionId, { server: connServer, transport: sseTransport });
 
-        console.error = (message: string) => server.sendLoggingMessage({ level: 'error', message });
+      connServer.connect(sseTransport).then(() => {
+        process.stderr.write(`Legacy SSE connection established (connectionId ${connectionId})\n`);
+      });
 
-        console.error(`Actual Budget MCP Server (SSE) started on port ${resolvedPort}`);
+      res.on('close', () => {
+        legacySseConnections.delete(connectionId);
+        connServer.close();
       });
     };
 
@@ -226,41 +216,43 @@ async function main(): Promise<void> {
       }
       const requestLabel = `${req.method} ${req.path}`;
       try {
-        let streamableTransport = sessionHeader ? streamableHttpTransports.get(sessionHeader) : undefined;
+        let session = sessionHeader ? streamableSessions.get(sessionHeader) : undefined;
 
-        if (!streamableTransport) {
+        if (!session) {
           if (req.method === 'POST' && isInitializeRequest(req.body)) {
             const remoteAddress = req.ip ?? req.socket.remoteAddress ?? 'unknown';
-            streamableTransport = new StreamableHTTPServerTransport({
+            const sessionServer = createServer({ enableWrite: !!enableWrite });
+            const streamableTransport = new StreamableHTTPServerTransport({
               sessionIdGenerator: () => randomUUID(),
               onsessioninitialized: (sessionId) => {
-                streamableHttpTransports.set(sessionId, streamableTransport!);
+                streamableSessions.set(sessionId, { server: sessionServer, transport: streamableTransport });
                 console.info(`Streamable HTTP session initialized (session ${sessionId}) from ${remoteAddress}`);
               },
               onsessionclosed: (sessionId) => {
-                streamableHttpTransports.delete(sessionId);
+                streamableSessions.delete(sessionId);
+                sessionServer.close();
                 console.info(`Streamable HTTP session closed (session ${sessionId})`);
               },
             });
 
+            // Reason: only remove the session from the map here. Calling
+            // sessionServer.close() in this handler would re-enter
+            // Server.close() -> transport.close() -> onclose, recursing until
+            // the process crashes with a stack overflow on disconnect (#171).
+            // Session-server lifecycle is handled by onsessionclosed above.
             streamableTransport.onclose = () => {
-              const activeSessionId = streamableTransport?.sessionId;
+              const activeSessionId = streamableTransport.sessionId;
               if (activeSessionId) {
-                streamableHttpTransports.delete(activeSessionId);
+                streamableSessions.delete(activeSessionId);
                 console.info(`Streamable HTTP transport closed (session ${activeSessionId})`);
               }
             };
 
             try {
-              await server.connect(streamableTransport);
-
-              console.log = (message: string) => server.sendLoggingMessage({ level: 'info', message });
-
-              console.error = (message: string) => server.sendLoggingMessage({ level: 'error', message });
-
-              console.error(`Actual Budget MCP Server (Streamable HTTP) started on port ${resolvedPort}`);
+              await sessionServer.connect(streamableTransport);
+              process.stderr.write(`Actual Budget MCP Server (Streamable HTTP) started on port ${resolvedPort}\n`);
             } catch (error) {
-              console.error(`Failed to connect streamable HTTP transport: ${toErrorMessage(error)}`);
+              process.stderr.write(`Failed to connect streamable HTTP transport: ${toErrorMessage(error)}\n`);
               res.status(500).json({
                 jsonrpc: '2.0',
                 error: {
@@ -271,6 +263,8 @@ async function main(): Promise<void> {
               });
               return;
             }
+
+            session = { server: sessionServer, transport: streamableTransport };
           } else {
             res.status(400).json({
               jsonrpc: '2.0',
@@ -284,21 +278,9 @@ async function main(): Promise<void> {
           }
         }
 
-        if (!streamableTransport) {
-          res.status(500).json({
-            jsonrpc: '2.0',
-            error: {
-              code: -32603,
-              message: 'Internal server error',
-            },
-            id: null,
-          });
-          return;
-        }
-
-        await streamableTransport.handleRequest(req, res, req.body);
+        await session.transport.handleRequest(req, res, req.body);
       } catch (error) {
-        console.error(`Streamable HTTP handler error for ${requestLabel}: ${toErrorMessage(error)}`);
+        process.stderr.write(`Streamable HTTP handler error for ${requestLabel}: ${toErrorMessage(error)}\n`);
 
         if (!res.headersSent) {
           res.status(500).json({
@@ -314,41 +296,48 @@ async function main(): Promise<void> {
     });
 
     app.post('/messages', bearerAuth, async (req: Request, res: Response) => {
-      if (transport) {
-        await transport.handlePostMessage(req, res, req.body);
+      const connectionId = req.query.connectionId as string | undefined;
+      const conn = connectionId ? legacySseConnections.get(connectionId) : undefined;
+      if (conn) {
+        await conn.transport.handlePostMessage(req, res, req.body);
       } else {
-        res.status(500).json({ error: 'Transport not initialized' });
+        res.status(400).json({ error: 'Invalid or missing connectionId' });
       }
     });
 
     app.listen(resolvedPort, (error) => {
       if (error) {
-        console.error('Error:', error);
+        process.stderr.write(`Error: ${toErrorMessage(error)}\n`);
       } else {
-        console.error(`Actual Budget MCP Server (SSE) started on port ${resolvedPort}`);
+        process.stderr.write(`Actual Budget MCP Server (HTTP) listening on port ${resolvedPort}\n`);
       }
     });
+
+    // SIGINT handler: close all active connections
+    process.on('SIGINT', () => {
+      process.stderr.write('SIGINT received, shutting down server\n');
+      for (const [, conn] of legacySseConnections) {
+        conn.server.close();
+      }
+      for (const [, session] of streamableSessions) {
+        session.server.close();
+        session.transport.close();
+      }
+      process.exit(0);
+    });
   } else {
+    const server = createServer({ enableWrite: !!enableWrite });
     const transport = new StdioServerTransport();
     await server.connect(transport);
     console.error('Actual Budget MCP Server (stdio) started');
+
+    process.on('SIGINT', () => {
+      console.error('SIGINT received, shutting down server');
+      server.close();
+      process.exit(0);
+    });
   }
 }
-
-setupResources(server);
-setupTools(server, enableWrite);
-setupPrompts(server);
-
-server.setRequestHandler(SetLevelRequestSchema, (request) => {
-  console.log(`--- Logging level: ${request.params.level}`);
-  return {};
-});
-
-process.on('SIGINT', () => {
-  console.error('SIGINT received, shutting down server');
-  server.close();
-  process.exit(0);
-});
 
 // Backstop: keep the process alive when something rejects without a handler
 // or throws synchronously outside any try/catch. Without these, a single bad
@@ -361,23 +350,7 @@ process.on('uncaughtException', (err) => {
   console.error(`Uncaught exception: ${toErrorMessage(err)}`);
 });
 
-main()
-  .then(() => {
-    if (!useSse) {
-      // TODO: Setup proper logging level change. Messages are available in the notification of MCP Inspector
-      console.log = (message: string) =>
-        server.sendLoggingMessage({
-          level: 'info',
-          message,
-        });
-      console.error = (message: string) =>
-        server.sendLoggingMessage({
-          level: 'error',
-          message,
-        });
-    }
-  })
-  .catch((error: unknown) => {
-    console.error(`Server error: ${toErrorMessage(error)}`);
-    process.exit(1);
-  });
+main().catch((error: unknown) => {
+  console.error(`Server error: ${toErrorMessage(error)}`);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { fetchAllAccounts } from './core/data/fetch-accounts.js';
 import { createServer } from './server.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
-// Reason: dotenv@17 prints to stdout by default, which corrupts MCP stdio JSON parsing.
+// quiet: dotenv@17 otherwise prints to stdout and corrupts MCP stdio JSON.
 dotenv.config({ path: '.env', quiet: true } as Parameters<typeof dotenv.config>[0]);
 
 // Argument parsing
@@ -169,7 +169,6 @@ async function main(): Promise<void> {
       process.stderr.write('Bearer authentication disabled - endpoints are public\n');
     }
 
-    // Per-connection Server + transport so concurrent clients don't clobber each other (#137).
     const legacySseConnections = new Map<string, { server: Server; transport: SSEServerTransport }>();
     const streamableSessions = new Map<string, { server: Server; transport: StreamableHTTPServerTransport }>();
 
@@ -193,7 +192,6 @@ async function main(): Promise<void> {
       const sseTransport = new SSEServerTransport(`/messages?connectionId=${connectionId}`, res);
       legacySseConnections.set(connectionId, { server: connServer, transport: sseTransport });
 
-      // Clean up on connect failure so /messages can't route to a dead connection.
       void connServer
         .connect(sseTransport)
         .then(() => {
@@ -248,9 +246,7 @@ async function main(): Promise<void> {
               },
             });
 
-            // Only drop the session here; calling sessionServer.close() would
-            // recurse via transport.close() -> onclose and crash (#171). Server
-            // lifecycle is handled by onsessionclosed above.
+            // Don't close the server here — it recurses into onclose and crashes (#171).
             streamableTransport.onclose = () => {
               const activeSessionId = streamableTransport.sessionId;
               if (activeSessionId) {
@@ -350,7 +346,6 @@ async function main(): Promise<void> {
   }
 }
 
-// Backstops so a stray rejection/throw doesn't crash the whole MCP server.
 process.on('unhandledRejection', (reason) => {
   console.error(`Unhandled promise rejection: ${toErrorMessage(reason)}`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,8 +169,7 @@ async function main(): Promise<void> {
       process.stderr.write('Bearer authentication disabled - endpoints are public\n');
     }
 
-    // Reason: each connection/session gets its own Server + transport so concurrent
-    // clients can't overwrite each other's transports or logging state (#137).
+    // Per-connection Server + transport so concurrent clients don't clobber each other (#137).
     const legacySseConnections = new Map<string, { server: Server; transport: SSEServerTransport }>();
     const streamableSessions = new Map<string, { server: Server; transport: StreamableHTTPServerTransport }>();
 
@@ -194,8 +193,7 @@ async function main(): Promise<void> {
       const sseTransport = new SSEServerTransport(`/messages?connectionId=${connectionId}`, res);
       legacySseConnections.set(connectionId, { server: connServer, transport: sseTransport });
 
-      // Reason: handle connect rejection so a failed connection doesn't leave a
-      // dead entry in legacySseConnections that /messages could later route to.
+      // Clean up on connect failure so /messages can't route to a dead connection.
       void connServer
         .connect(sseTransport)
         .then(() => {
@@ -250,11 +248,9 @@ async function main(): Promise<void> {
               },
             });
 
-            // Reason: only remove the session from the map here. Calling
-            // sessionServer.close() in this handler would re-enter
-            // Server.close() -> transport.close() -> onclose, recursing until
-            // the process crashes with a stack overflow on disconnect (#171).
-            // Session-server lifecycle is handled by onsessionclosed above.
+            // Only drop the session here; calling sessionServer.close() would
+            // recurse via transport.close() -> onclose and crash (#171). Server
+            // lifecycle is handled by onsessionclosed above.
             streamableTransport.onclose = () => {
               const activeSessionId = streamableTransport.sessionId;
               if (activeSessionId) {
@@ -354,9 +350,7 @@ async function main(): Promise<void> {
   }
 }
 
-// Backstop: keep the process alive when something rejects without a handler
-// or throws synchronously outside any try/catch. Without these, a single bad
-// tool call (or upstream API misbehavior) crashes the entire MCP server.
+// Backstops so a stray rejection/throw doesn't crash the whole MCP server.
 process.on('unhandledRejection', (reason) => {
   console.error(`Unhandled promise rejection: ${toErrorMessage(reason)}`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,9 +194,24 @@ async function main(): Promise<void> {
       const sseTransport = new SSEServerTransport(`/messages?connectionId=${connectionId}`, res);
       legacySseConnections.set(connectionId, { server: connServer, transport: sseTransport });
 
-      connServer.connect(sseTransport).then(() => {
-        process.stderr.write(`Legacy SSE connection established (connectionId ${connectionId})\n`);
-      });
+      // Reason: handle connect rejection so a failed connection doesn't leave a
+      // dead entry in legacySseConnections that /messages could later route to.
+      void connServer
+        .connect(sseTransport)
+        .then(() => {
+          process.stderr.write(`Legacy SSE connection established (connectionId ${connectionId})\n`);
+        })
+        .catch((error: unknown) => {
+          legacySseConnections.delete(connectionId);
+          process.stderr.write(
+            `Failed to connect legacy SSE transport (connectionId ${connectionId}): ${toErrorMessage(error)}\n`
+          );
+          if (!res.headersSent) {
+            res.status(500).end();
+          } else {
+            res.end();
+          }
+        });
 
       res.on('close', () => {
         legacySseConnections.delete(connectionId);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,51 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { describe, expect, it, vi } from 'vitest';
+import { createServer } from './server.js';
+
+vi.mock('./resources.js', () => ({
+  setupResources: vi.fn(),
+}));
+
+vi.mock('./tools/index.js', () => ({
+  setupTools: vi.fn(),
+}));
+
+vi.mock('./prompts.js', () => ({
+  setupPrompts: vi.fn(),
+}));
+
+import { setupResources } from './resources.js';
+import { setupTools } from './tools/index.js';
+import { setupPrompts } from './prompts.js';
+
+describe('createServer', () => {
+  it('returns a configured Server instance (happy path)', () => {
+    const server = createServer({ enableWrite: false });
+
+    expect(server).toBeInstanceOf(Server);
+    expect(setupResources).toHaveBeenCalledWith(server);
+    expect(setupTools).toHaveBeenCalledWith(server, false);
+    expect(setupPrompts).toHaveBeenCalledWith(server);
+  });
+
+  it('passes enableWrite: true through to setupTools', () => {
+    vi.mocked(setupTools).mockClear();
+    const server = createServer({ enableWrite: true });
+
+    expect(setupTools).toHaveBeenCalledWith(server, true);
+  });
+
+  it('creates an independent instance per call (no shared state across connections)', () => {
+    vi.mocked(setupResources).mockClear();
+    vi.mocked(setupTools).mockClear();
+    vi.mocked(setupPrompts).mockClear();
+
+    const server1 = createServer({ enableWrite: false });
+    const server2 = createServer({ enableWrite: true });
+
+    expect(server1).not.toBe(server2);
+    expect(setupResources).toHaveBeenCalledTimes(2);
+    expect(setupTools).toHaveBeenCalledTimes(2);
+    expect(setupPrompts).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,5 +1,6 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { describe, expect, it, vi } from 'vitest';
+import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer } from './server.js';
 
 vi.mock('./resources.js', () => ({
@@ -19,7 +20,14 @@ import { setupTools } from './tools/index.js';
 import { setupPrompts } from './prompts.js';
 
 describe('createServer', () => {
-  it('returns a configured Server instance (happy path)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(setupResources).mockReset();
+    vi.mocked(setupTools).mockReset();
+    vi.mocked(setupPrompts).mockReset();
+  });
+
+  it('wires up resources, tools, and prompts on the returned server (happy path)', () => {
     const server = createServer({ enableWrite: false });
 
     expect(server).toBeInstanceOf(Server);
@@ -28,24 +36,38 @@ describe('createServer', () => {
     expect(setupPrompts).toHaveBeenCalledWith(server);
   });
 
-  it('passes enableWrite: true through to setupTools', () => {
-    vi.mocked(setupTools).mockClear();
-    const server = createServer({ enableWrite: true });
-
-    expect(setupTools).toHaveBeenCalledWith(server, true);
-  });
-
-  it('creates an independent instance per call (no shared state across connections)', () => {
-    vi.mocked(setupResources).mockClear();
-    vi.mocked(setupTools).mockClear();
-    vi.mocked(setupPrompts).mockClear();
-
+  it('creates an independent instance per call so concurrent connections never share state (edge case)', () => {
     const server1 = createServer({ enableWrite: false });
     const server2 = createServer({ enableWrite: true });
 
     expect(server1).not.toBe(server2);
-    expect(setupResources).toHaveBeenCalledTimes(2);
-    expect(setupTools).toHaveBeenCalledTimes(2);
-    expect(setupPrompts).toHaveBeenCalledTimes(2);
+    // enableWrite must be threaded through per instance.
+    expect(setupTools).toHaveBeenNthCalledWith(1, server1, false);
+    expect(setupTools).toHaveBeenNthCalledWith(2, server2, true);
+  });
+
+  it('registers a SetLevel handler that logs to stderr and returns an empty result', () => {
+    // Capture the handler registered for the logging/setLevel request.
+    const setRequestHandlerSpy = vi.spyOn(Server.prototype, 'setRequestHandler');
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    createServer({ enableWrite: false });
+
+    const registration = setRequestHandlerSpy.mock.calls.find(([schema]) => schema === SetLevelRequestSchema);
+    expect(registration).toBeDefined();
+
+    const handler = registration![1] as unknown as (request: { params: { level: string } }, extra: unknown) => unknown;
+    const result = handler({ params: { level: 'debug' } }, {});
+
+    expect(result).toEqual({});
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('debug'));
+  });
+
+  it('propagates errors from setup steps so a misconfigured server fails fast (failure case)', () => {
+    vi.mocked(setupTools).mockImplementationOnce(() => {
+      throw new Error('tool setup failed');
+    });
+
+    expect(() => createServer({ enableWrite: false })).toThrow('tool setup failed');
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,10 +5,8 @@ import { setupPrompts } from './prompts.js';
 import { setupResources } from './resources.js';
 import { setupTools } from './tools/index.js';
 
-// Reason: read the version from package.json at runtime rather than importing it.
-// A static JSON import would pull package.json (outside rootDir: ./src) into the
-// compilation and break the build (TS6059). Resolving relative to import.meta.url
-// works both from build/ (build/../package.json) and from src/ under tests.
+// Read the version at runtime; a static JSON import of package.json (outside
+// rootDir: ./src) would break the build (TS6059).
 const { version: SERVER_VERSION } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
   version: string;
 };
@@ -18,13 +16,8 @@ interface CreateServerOptions {
 }
 
 /**
- * Creates and configures a new MCP Server instance with all resources, tools, and prompts.
- *
- * A fresh instance is created per connection/session so that concurrent HTTP/SSE
- * clients never share transports or logging state with one another.
- *
- * @param options - Server configuration options
- * @returns A fully configured Server instance ready to be connected to a transport
+ * Create a fresh MCP Server per connection/session so concurrent HTTP/SSE clients
+ * never share transports or logging state.
  */
 export function createServer(options: CreateServerOptions): Server {
   const server = new Server(
@@ -47,8 +40,7 @@ export function createServer(options: CreateServerOptions): Server {
   setupPrompts(server);
 
   server.setRequestHandler(SetLevelRequestSchema, (request) => {
-    // Reason: write directly to stderr instead of overriding console, which would
-    // race across concurrent connections sharing the global console object.
+    // stderr, not console: avoids races across concurrent connections.
     process.stderr.write(`--- Logging level: ${request.params.level}\n`);
     return {};
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,48 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { setupPrompts } from './prompts.js';
+import { setupResources } from './resources.js';
+import { setupTools } from './tools/index.js';
+
+interface CreateServerOptions {
+  enableWrite: boolean;
+}
+
+/**
+ * Creates and configures a new MCP Server instance with all resources, tools, and prompts.
+ *
+ * A fresh instance is created per connection/session so that concurrent HTTP/SSE
+ * clients never share transports or logging state with one another.
+ *
+ * @param options - Server configuration options
+ * @returns A fully configured Server instance ready to be connected to a transport
+ */
+export function createServer(options: CreateServerOptions): Server {
+  const server = new Server(
+    {
+      name: 'Actual Budget',
+      version: '1.0.0',
+    },
+    {
+      capabilities: {
+        resources: {},
+        tools: {},
+        prompts: {},
+        logging: {},
+      },
+    }
+  );
+
+  setupResources(server);
+  setupTools(server, options.enableWrite);
+  setupPrompts(server);
+
+  server.setRequestHandler(SetLevelRequestSchema, (request) => {
+    // Reason: write directly to stderr instead of overriding console, which would
+    // race across concurrent connections sharing the global console object.
+    process.stderr.write(`--- Logging level: ${request.params.level}\n`);
+    return {};
+  });
+
+  return server;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,8 +5,7 @@ import { setupPrompts } from './prompts.js';
 import { setupResources } from './resources.js';
 import { setupTools } from './tools/index.js';
 
-// Read the version at runtime; a static JSON import of package.json (outside
-// rootDir: ./src) would break the build (TS6059).
+// package.json is outside rootDir, so read it at runtime instead of importing it.
 const { version: SERVER_VERSION } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
   version: string;
 };
@@ -15,10 +14,6 @@ interface CreateServerOptions {
   enableWrite: boolean;
 }
 
-/**
- * Create a fresh MCP Server per connection/session so concurrent HTTP/SSE clients
- * never share transports or logging state.
- */
 export function createServer(options: CreateServerOptions): Server {
   const server = new Server(
     {
@@ -40,7 +35,6 @@ export function createServer(options: CreateServerOptions): Server {
   setupPrompts(server);
 
   server.setRequestHandler(SetLevelRequestSchema, (request) => {
-    // stderr, not console: avoids races across concurrent connections.
     process.stderr.write(`--- Logging level: ${request.params.level}\n`);
     return {};
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,17 @@
+import { readFileSync } from 'node:fs';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { setupPrompts } from './prompts.js';
 import { setupResources } from './resources.js';
 import { setupTools } from './tools/index.js';
+
+// Reason: read the version from package.json at runtime rather than importing it.
+// A static JSON import would pull package.json (outside rootDir: ./src) into the
+// compilation and break the build (TS6059). Resolving relative to import.meta.url
+// works both from build/ (build/../package.json) and from src/ under tests.
+const { version: SERVER_VERSION } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+  version: string;
+};
 
 interface CreateServerOptions {
   enableWrite: boolean;
@@ -21,7 +30,7 @@ export function createServer(options: CreateServerOptions): Server {
   const server = new Server(
     {
       name: 'Actual Budget',
-      version: '1.0.0',
+      version: SERVER_VERSION,
     },
     {
       capabilities: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
-    include: ['src/core/**/*.test.ts', 'src/tools/**/*.test.ts'],
+    include: ['src/**/*.test.ts'],
     globals: true,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Ports three stability fixes from upstream (s-stefanov/actual-mcp) that the
fork had diverged from, adapted to the fork's code:

- Per-connection MCP Server instances (#137): extract a createServer()
  factory into src/server.ts and give each legacy-SSE connection and each
  streamable-HTTP session its own Server + transport, routed via a
  connectionId query param for SSE. Previously a single global Server was
  shared across all HTTP/SSE clients, so concurrent connections overwrote
  each other's transports and console overrides. HTTP mode now writes logs
  via process.stderr.write instead of mutating the global console, removing
  the race entirely. Stdio mode keeps a single server.

- Avoid infinite recursion on streamable disconnect (#171): the per-session
  onclose handler only drops the session from the map; server lifecycle is
  handled by onsessionclosed. Closing the server inside onclose would
  re-enter transport.close() -> onclose and crash with a stack overflow.

- Stabilize API init/shutdown (#96): set initializing = true before the
  first await in initActualApi so concurrent callers actually wait on the
  in-progress init instead of racing into api.init(); wrap api.shutdown()
  in try/catch/finally so a failing shutdown still resets state. Also pass
  quiet: true to dotenv (v17 prints to stdout, corrupting stdio JSON).

The fork's crash backstops (unhandledRejection/uncaughtException) are
preserved. Adds tests for the createServer factory and the init/shutdown
behavior; broadens the vitest include to src/**/*.test.ts.

https://claude.ai/code/session_01W1jZYA6PciukpwFkLxL2sN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server factory now creates per-session/per-connection isolated servers and exposes a request to adjust logging level.

* **Bug Fixes**
  * Serialized and memoized API initialization to prevent races; failures clear state so retries work.
  * Shutdown now waits for in-flight init, handles errors gracefully, and resets internal init state.
  * Improved SSE/streamable routing, validation, and lifecycle cleanup.

* **Tests**
  * Expanded test coverage for init/shutdown concurrency, failure paths, and server wiring.

* **Chores**
  * Startup/config refinements (quieter dotenv, simplified startup error handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->