### PR TITLE
perf: cache the downloaded budget between tool calls with a TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ ACTUAL_BUDGET_SYNC_ID=
 ACTUAL_BUDGET_ENCRYPTION_PASSWORD=
 # Optional: ISO 4217 currency code for formatting amounts (e.g., "USD", "EUR", "GBP"). If not set, amounts are displayed without currency symbols.
 ACTUAL_MCP_CURRENCY_SYMBOL=
+# Optional: seconds to keep the downloaded budget cached between tool calls instead of
+# re-downloading on every call. Cached data is refreshed via sync on each reuse.
+# Defaults to 60. Set to 0 to disable caching (shut down after every call).
+ACTUAL_MCP_CACHE_TTL_SECONDS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@
 
 - **Update `README.md`** when new features are added, dependencies change, or setup steps are modified.
 - **Comment non-obvious code** and ensure everything is understandable to a mid-level developer.
+- **Do not write obvious code comments.** Avoid comments that merely restate what the code plainly does (e.g. `// first call: fresh init` next to an assertion, or a JSDoc that repeats the function name). Keep only notes that add information the code does not convey on its own — the _why_, not the _what_: rationale, edge cases, and surprising behavior. Prefer self-explanatory names over narration.
 - When writing complex logic, **add an inline `# Reason:` comment** explaining the why, not just the what.
 
 ### 🧠 AI Behavior Rules

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ export ACTUAL_MCP_CURRENCY_SYMBOL="USD"  # For US Dollars: $1,234.56
 # export ACTUAL_MCP_CURRENCY_SYMBOL="GBP"  # For British Pounds: £1,234.56
 ```
 
+Optional: budget cache TTL
+
+By default the server keeps the downloaded budget cached in memory for **60 seconds** between
+tool calls instead of re-downloading it every time, which makes back-to-back requests much
+faster. Cached data is kept current by syncing the latest changes from your Actual server on
+each reuse, so you still see up-to-date data. Tune or disable it with `ACTUAL_MCP_CACHE_TTL_SECONDS`:
+
+```bash
+export ACTUAL_MCP_CACHE_TTL_SECONDS="120"  # keep the budget warm for 2 minutes
+# export ACTUAL_MCP_CACHE_TTL_SECONDS="0"  # disable caching (re-download every call)
+```
+
 ## Usage with Claude Desktop
 
 To use this server with Claude Desktop, add it to your Claude configuration:

--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -6,6 +6,7 @@ const mockApi = {
   getBudgets: vi.fn(),
   downloadBudget: vi.fn(),
   shutdown: vi.fn(),
+  sync: vi.fn(),
 };
 
 vi.mock('@actual-app/api', () => ({
@@ -37,6 +38,8 @@ describe('actual-api init/shutdown stability (#96)', () => {
     mockApi.init.mockResolvedValue(undefined);
     mockApi.downloadBudget.mockResolvedValue(undefined);
     mockApi.shutdown.mockResolvedValue(undefined);
+    mockApi.sync.mockResolvedValue(undefined);
+    delete process.env.ACTUAL_MCP_CACHE_TTL_SECONDS;
   });
 
   afterEach(() => {
@@ -100,8 +103,9 @@ describe('actual-api init/shutdown stability (#96)', () => {
 
     // First attempt rejects...
     await expect(initActualApi()).rejects.toThrow('init failed');
-    // ...and a later call retries instead of reusing the failed promise.
-    await expect(initActualApi()).resolves.toBeUndefined();
+    // ...and a later call retries instead of reusing the failed promise. The
+    // retry is a fresh init (not a cached reuse), so it resolves to false.
+    await expect(initActualApi()).resolves.toBe(false);
     expect(mockApi.init).toHaveBeenCalledTimes(2);
   });
 
@@ -126,6 +130,73 @@ describe('actual-api init/shutdown stability (#96)', () => {
 
     resolveInit();
     await Promise.all([initCall, shutdownCall]);
+    expect(mockApi.shutdown).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('actual-api budget caching', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.getBudgets.mockResolvedValue([{ id: 'budget-1', cloudFileId: 'budget-1' }]);
+    mockApi.init.mockResolvedValue(undefined);
+    mockApi.downloadBudget.mockResolvedValue(undefined);
+    mockApi.shutdown.mockResolvedValue(undefined);
+    mockApi.sync.mockResolvedValue(undefined);
+    delete process.env.ACTUAL_MCP_CACHE_TTL_SECONDS;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('reports a fresh init vs. a cached reuse via the return value (happy path)', async () => {
+    const { initActualApi } = await loadModule();
+
+    expect(await initActualApi()).toBe(false); // first call: fresh init + download
+    expect(await initActualApi()).toBe(true); // second call: reused cached budget
+    expect(mockApi.downloadBudget).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs the cached budget from the server but is a no-op before init (edge case)', async () => {
+    const { initActualApi, syncBudget } = await loadModule();
+
+    await syncBudget();
+    expect(mockApi.sync).not.toHaveBeenCalled(); // nothing initialized yet
+
+    await initActualApi();
+    await syncBudget();
+    expect(mockApi.sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the API warm for the TTL and shuts down only after it elapses', async () => {
+    vi.useFakeTimers();
+    process.env.ACTUAL_MCP_CACHE_TTL_SECONDS = '60';
+    const { initActualApi, scheduleShutdown } = await loadModule();
+
+    await initActualApi();
+    scheduleShutdown();
+
+    // Still within the TTL -> not shut down yet.
+    vi.advanceTimersByTime(59_000);
+    expect(mockApi.shutdown).not.toHaveBeenCalled();
+
+    // TTL elapsed -> idle shutdown fires.
+    vi.advanceTimersByTime(2_000);
+    await vi.runAllTimersAsync();
+    expect(mockApi.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('shuts down immediately when caching is disabled with TTL=0 (failure/disabled case)', async () => {
+    process.env.ACTUAL_MCP_CACHE_TTL_SECONDS = '0';
+    const { initActualApi, scheduleShutdown } = await loadModule();
+
+    await initActualApi();
+    scheduleShutdown();
+    // Allow the void shutdownActualApi() promise to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
     expect(mockApi.shutdown).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -153,8 +153,8 @@ describe('actual-api budget caching', () => {
   it('reports a fresh init vs. a cached reuse via the return value (happy path)', async () => {
     const { initActualApi } = await loadModule();
 
-    expect(await initActualApi()).toBe(false); // first call: fresh init + download
-    expect(await initActualApi()).toBe(true); // second call: reused cached budget
+    expect(await initActualApi()).toBe(false);
+    expect(await initActualApi()).toBe(true);
     expect(mockApi.downloadBudget).toHaveBeenCalledTimes(1);
   });
 
@@ -162,7 +162,7 @@ describe('actual-api budget caching', () => {
     const { initActualApi, syncBudget } = await loadModule();
 
     await syncBudget();
-    expect(mockApi.sync).not.toHaveBeenCalled(); // nothing initialized yet
+    expect(mockApi.sync).not.toHaveBeenCalled();
 
     await initActualApi();
     await syncBudget();

--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -192,11 +192,36 @@ describe('actual-api budget caching', () => {
     const { initActualApi, scheduleShutdown } = await loadModule();
 
     await initActualApi();
-    scheduleShutdown();
-    // Allow the void shutdownActualApi() promise to settle.
-    await Promise.resolve();
-    await Promise.resolve();
+    // TTL=0 returns an awaitable teardown so the caller can ensure it completed.
+    await scheduleShutdown();
 
     expect(mockApi.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for an in-flight shutdown to finish before re-initializing (edge case)', async () => {
+    const { initActualApi, shutdownActualApi } = await loadModule();
+
+    let resolveShutdown: () => void = () => {};
+    mockApi.shutdown.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveShutdown = resolve;
+        })
+    );
+
+    await initActualApi();
+    const shutdownCall = shutdownActualApi();
+    const reinit = initActualApi();
+
+    // Shutdown is mid-flight, so re-init must not start a second api.init()
+    // that would race the in-progress api.shutdown().
+    await Promise.resolve();
+    expect(mockApi.init).toHaveBeenCalledTimes(1);
+
+    resolveShutdown();
+    await Promise.all([shutdownCall, reinit]);
+
+    expect(mockApi.shutdown).toHaveBeenCalledTimes(1);
+    expect(mockApi.init).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -14,6 +14,7 @@ import { RuleEntity, TransactionEntity } from '@actual-app/api/@types/loot-core/
 const DEFAULT_DATA_DIR: string = path.resolve(os.homedir() || '.', '.actual');
 
 let initPromise: Promise<void> | null = null;
+let shutdownPromise: Promise<void> | null = null;
 let shutdownTimer: ReturnType<typeof setTimeout> | null = null;
 
 const DEFAULT_CACHE_TTL_SECONDS = 60;
@@ -33,6 +34,12 @@ function getCacheTtlMs(): number {
 
 export async function initActualApi(): Promise<boolean> {
   cancelScheduledShutdown();
+  // Reason: a TTL-triggered shutdown may already be mid-flight (api.shutdown()
+  // not yet resolved). Wait for it to finish before re-initializing, otherwise
+  // loadBudget() would race api.init() against the in-progress api.shutdown().
+  if (shutdownPromise) {
+    await shutdownPromise;
+  }
   const reused = initPromise !== null;
   if (!initPromise) {
     initPromise = loadBudget();
@@ -77,19 +84,28 @@ async function loadBudget(): Promise<void> {
 
 export async function shutdownActualApi(): Promise<void> {
   cancelScheduledShutdown();
+  if (shutdownPromise) return shutdownPromise;
   const pending = initPromise;
   if (!pending) return;
   initPromise = null;
-  try {
-    await pending;
-  } catch {
-    return;
-  }
-  try {
-    await api.shutdown();
-  } catch (err) {
-    console.error('Error shutting down Actual Budget API:', err);
-  }
+  shutdownPromise = (async () => {
+    try {
+      try {
+        await pending;
+      } catch {
+        // Init itself failed; there is nothing initialized to tear down.
+        return;
+      }
+      try {
+        await api.shutdown();
+      } catch (err) {
+        console.error('Error shutting down Actual Budget API:', err);
+      }
+    } finally {
+      shutdownPromise = null;
+    }
+  })();
+  return shutdownPromise;
 }
 
 export function cancelScheduledShutdown(): void {
@@ -99,12 +115,13 @@ export function cancelScheduledShutdown(): void {
   }
 }
 
-export function scheduleShutdown(): void {
+export function scheduleShutdown(): Promise<void> | void {
   cancelScheduledShutdown();
   const ttlMs = getCacheTtlMs();
   if (ttlMs <= 0) {
-    void shutdownActualApi();
-    return;
+    // Reason: TTL=0 disables caching, so the caller can await teardown to
+    // guarantee the legacy "shut down after every call" behavior completes.
+    return shutdownActualApi();
   }
   shutdownTimer = setTimeout(() => {
     shutdownTimer = null;

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -14,15 +14,34 @@ import { RuleEntity, TransactionEntity } from '@actual-app/api/@types/loot-core/
 const DEFAULT_DATA_DIR: string = path.resolve(os.homedir() || '.', '.actual');
 
 let initPromise: Promise<void> | null = null;
+let shutdownTimer: ReturnType<typeof setTimeout> | null = null;
 
-export function initActualApi(): Promise<void> {
+const DEFAULT_CACHE_TTL_SECONDS = 60;
+
+function getCacheTtlMs(): number {
+  const raw = process.env.ACTUAL_MCP_CACHE_TTL_SECONDS;
+  if (raw === undefined || raw.trim() === '') {
+    return DEFAULT_CACHE_TTL_SECONDS * 1000;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(`Invalid ACTUAL_MCP_CACHE_TTL_SECONDS="${raw}"; falling back to ${DEFAULT_CACHE_TTL_SECONDS}s`);
+    return DEFAULT_CACHE_TTL_SECONDS * 1000;
+  }
+  return parsed * 1000;
+}
+
+export async function initActualApi(): Promise<boolean> {
+  cancelScheduledShutdown();
+  const reused = initPromise !== null;
   if (!initPromise) {
     initPromise = loadBudget();
     initPromise.catch(() => {
       initPromise = null;
     });
   }
-  return initPromise;
+  await initPromise;
+  return reused;
 }
 
 async function loadBudget(): Promise<void> {
@@ -57,6 +76,7 @@ async function loadBudget(): Promise<void> {
 }
 
 export async function shutdownActualApi(): Promise<void> {
+  cancelScheduledShutdown();
   const pending = initPromise;
   if (!pending) return;
   initPromise = null;
@@ -69,6 +89,36 @@ export async function shutdownActualApi(): Promise<void> {
     await api.shutdown();
   } catch (err) {
     console.error('Error shutting down Actual Budget API:', err);
+  }
+}
+
+export function cancelScheduledShutdown(): void {
+  if (shutdownTimer) {
+    clearTimeout(shutdownTimer);
+    shutdownTimer = null;
+  }
+}
+
+export function scheduleShutdown(): void {
+  cancelScheduledShutdown();
+  const ttlMs = getCacheTtlMs();
+  if (ttlMs <= 0) {
+    void shutdownActualApi();
+    return;
+  }
+  shutdownTimer = setTimeout(() => {
+    shutdownTimer = null;
+    void shutdownActualApi();
+  }, ttlMs);
+  shutdownTimer.unref?.();
+}
+
+export async function syncBudget(): Promise<void> {
+  if (!initPromise) return;
+  try {
+    await api.sync();
+  } catch (err) {
+    console.error('Error syncing Actual Budget data:', err);
   }
 }
 

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -2,7 +2,6 @@ import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the Actual API lifecycle so we can assert the cache wiring without a real budget.
 vi.mock('../actual-api.js', () => ({
   initActualApi: vi.fn(),
   syncBudget: vi.fn(),
@@ -14,9 +13,6 @@ import { setupTools } from './index.js';
 
 type ToolHandler = (request: { params: { name: string; arguments?: unknown } }, extra: unknown) => Promise<unknown>;
 
-/**
- * Build the tools and return the registered call-tool handler.
- */
 function getCallToolHandler(enableWrite = false): ToolHandler {
   const handlers = new Map<unknown, unknown>();
   const fakeServer = {
@@ -36,7 +32,7 @@ describe('tools call handler — budget cache wiring', () => {
   });
 
   it('syncs when a cached budget was reused, then schedules shutdown (happy path)', async () => {
-    vi.mocked(initActualApi).mockResolvedValue(true); // reused cached budget
+    vi.mocked(initActualApi).mockResolvedValue(true);
     const handler = getCallToolHandler();
 
     await handler({ params: { name: 'does-not-exist', arguments: {} } }, {});
@@ -47,7 +43,7 @@ describe('tools call handler — budget cache wiring', () => {
   });
 
   it('skips sync after a fresh init but still schedules shutdown (edge case)', async () => {
-    vi.mocked(initActualApi).mockResolvedValue(false); // freshly initialized -> already current
+    vi.mocked(initActualApi).mockResolvedValue(false);
     const handler = getCallToolHandler();
 
     const result = await handler({ params: { name: 'does-not-exist', arguments: {} } }, {});

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,0 +1,72 @@
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the Actual API lifecycle so we can assert the cache wiring without a real budget.
+vi.mock('../actual-api.js', () => ({
+  initActualApi: vi.fn(),
+  syncBudget: vi.fn(),
+  scheduleShutdown: vi.fn(),
+}));
+
+import { initActualApi, syncBudget, scheduleShutdown } from '../actual-api.js';
+import { setupTools } from './index.js';
+
+type ToolHandler = (request: { params: { name: string; arguments?: unknown } }, extra: unknown) => Promise<unknown>;
+
+/**
+ * Build the tools and return the registered call-tool handler.
+ */
+function getCallToolHandler(enableWrite = false): ToolHandler {
+  const handlers = new Map<unknown, unknown>();
+  const fakeServer = {
+    setRequestHandler: (schema: unknown, handler: unknown) => {
+      handlers.set(schema, handler);
+    },
+  } as unknown as Server;
+
+  setupTools(fakeServer, enableWrite);
+  return handlers.get(CallToolRequestSchema) as ToolHandler;
+}
+
+describe('tools call handler — budget cache wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(scheduleShutdown).mockReturnValue(undefined);
+  });
+
+  it('syncs when a cached budget was reused, then schedules shutdown (happy path)', async () => {
+    vi.mocked(initActualApi).mockResolvedValue(true); // reused cached budget
+    const handler = getCallToolHandler();
+
+    await handler({ params: { name: 'does-not-exist', arguments: {} } }, {});
+
+    expect(initActualApi).toHaveBeenCalledTimes(1);
+    expect(syncBudget).toHaveBeenCalledTimes(1);
+    expect(scheduleShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips sync after a fresh init but still schedules shutdown (edge case)', async () => {
+    vi.mocked(initActualApi).mockResolvedValue(false); // freshly initialized -> already current
+    const handler = getCallToolHandler();
+
+    const result = await handler({ params: { name: 'does-not-exist', arguments: {} } }, {});
+
+    expect(syncBudget).not.toHaveBeenCalled();
+    expect(scheduleShutdown).toHaveBeenCalledTimes(1);
+    // Unknown tool surfaces as a structured error rather than throwing.
+    expect(result).toMatchObject({ isError: true });
+  });
+
+  it('schedules shutdown even when initialization throws (failure case)', async () => {
+    vi.mocked(initActualApi).mockRejectedValue(new Error('init boom'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = getCallToolHandler();
+
+    const result = await handler({ params: { name: 'get-accounts', arguments: {} } }, {});
+
+    expect(result).toMatchObject({ isError: true });
+    // finally must always run so the API doesn't stay pinned open after a failure.
+    expect(scheduleShutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -97,7 +97,7 @@ export const setupTools = (server: Server, enableWrite: boolean): void => {
       console.error(`Error executing tool ${toolName}:`, err);
       return errorFromCatch(err, { toolName });
     } finally {
-      scheduleShutdown();
+      await scheduleShutdown();
     }
   });
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,7 +4,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { initActualApi, shutdownActualApi } from '../actual-api.js';
+import { initActualApi, scheduleShutdown, syncBudget } from '../actual-api.js';
 import { error, errorFromCatch } from '../utils/response.js';
 
 import * as balanceHistory from './balance-history/index.js';
@@ -81,7 +81,10 @@ export const setupTools = (server: Server, enableWrite: boolean): void => {
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name: toolName, arguments: args } = request.params;
     try {
-      await initActualApi();
+      const reused = await initActualApi();
+      if (reused) {
+        await syncBudget();
+      }
 
       const tool = allTools.find((t) => t.schema.name === toolName);
       if (!tool) {
@@ -94,7 +97,7 @@ export const setupTools = (server: Server, enableWrite: boolean): void => {
       console.error(`Error executing tool ${toolName}:`, err);
       return errorFromCatch(err, { toolName });
     } finally {
-      await shutdownActualApi();
+      scheduleShutdown();
     }
   });
 };


### PR DESCRIPTION
## Problem

Every tool call ran `initActualApi()` and then `shutdownActualApi()` in a `finally` block, so the budget was **fully re-downloaded** (`api.init()` + `downloadBudget()`) on *every single call*. That's a significant per-call latency hit for interactive use.

## Change

Keep the downloaded budget **warm** between calls instead of tearing it down each time:

- `initActualApi()` now cancels any pending idle shutdown and returns whether it **reused** a cached instance (`true`) or performed a fresh init (`false`).
- On reuse, the tool handler calls `syncBudget()` (`api.sync()`) to pull the latest server-side changes — so **cached data stays fresh** rather than going stale (incremental sync is far cheaper than a full re-download).
- `scheduleShutdown()` releases the API only after `ACTUAL_MCP_CACHE_TTL_SECONDS` of **inactivity** (default **60s**). Set to `0` to disable caching and restore the legacy shut-down-after-every-call behavior.

### Freshness

A naive "keep the file" cache would drift out of sync with the server (other clients, bank sync, the web UI). This avoids that by syncing on every cached reuse, leaving data as current as the old re-download-every-time approach — just without the cost.

## Tests

- `actual-api.test.ts`: fresh-vs-reused return value, `syncBudget` behavior, the TTL idle shutdown (fake timers), and `TTL=0` immediate shutdown.
- `tools/index.test.ts`: the call handler syncs only on reuse, skips sync after a fresh init, and always `scheduleShutdown()`s in `finally` (even when init throws).

Documents `ACTUAL_MCP_CACHE_TTL_SECONDS` in `README.md` and `.env.example`.

## Notes

- Built on top of the stability fixes from #35 (now merged); rebased onto `main`, so this diff is the cache change only.

https://claude.ai/code/session_01W1jZYA6PciukpwFkLxL2sN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `ACTUAL_MCP_CACHE_TTL_SECONDS` environment variable to control budget data caching duration (default: 60 seconds; set to 0 to disable).

* **Documentation**
  * Updated configuration documentation to include the new cache TTL setting.

* **Tests**
  * Added test coverage for budget caching behavior and request lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->