### PR TITLE
feat(get-transactions): add excludeTransfers option

### DIFF
--- a/src/tools/get-transactions/index.test.ts
+++ b/src/tools/get-transactions/index.test.ts
@@ -217,6 +217,88 @@ describe('get-transactions tool', () => {
     });
   });
 
+  describe('handler - excludeTransfers filtering', () => {
+    const withTransfers: Transaction[] = [
+      {
+        id: 'tx-spend',
+        account: 'account-1',
+        date: '2025-12-01',
+        amount: 5000,
+        payee_name: 'Coffee Shop',
+        category: 'cat-1',
+        category_name: 'Food',
+      },
+      {
+        id: 'tx-uncat',
+        account: 'account-1',
+        date: '2025-12-02',
+        amount: 10000,
+        payee_name: 'Unknown Store',
+      },
+      {
+        id: 'tx-transfer-out',
+        account: 'account-1',
+        date: '2025-12-03',
+        amount: -20000,
+        payee_name: 'Credit Card',
+        transfer_id: 'tx-transfer-in',
+      },
+    ];
+
+    it('should exclude transfers but keep categorized transactions when excludeTransfers is true', async () => {
+      mockFetch.mockResolvedValue(withTransfers);
+
+      const args: GetTransactionsArgs = {
+        accountId: 'account-1',
+        excludeTransfers: true,
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('tx-spend');
+      expect(result.content[0].text).toContain('tx-uncat');
+      expect(result.content[0].text).not.toContain('tx-transfer-out');
+      expect(result.content[0].text).toContain('Excluding transfers');
+      expect(result.content[0].text).toContain('Matching Transactions: 2/3');
+    });
+
+    it('should include transfers when excludeTransfers is false', async () => {
+      mockFetch.mockResolvedValue(withTransfers);
+
+      const args: GetTransactionsArgs = {
+        accountId: 'account-1',
+        excludeTransfers: false,
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('tx-transfer-out');
+      expect(result.content[0].text).not.toContain('Excluding transfers');
+    });
+
+    it('should not duplicate the transfer filter when both uncategorizedOnly and excludeTransfers are true', async () => {
+      mockFetch.mockResolvedValue(withTransfers);
+
+      const args: GetTransactionsArgs = {
+        accountId: 'account-1',
+        uncategorizedOnly: true,
+        excludeTransfers: true,
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('tx-uncat');
+      expect(result.content[0].text).not.toContain('tx-spend');
+      expect(result.content[0].text).not.toContain('tx-transfer-out');
+      expect(result.content[0].text).toContain('Uncategorized only');
+      expect(result.content[0].text).not.toContain('Excluding transfers');
+      expect(result.content[0].text).toContain('Matching Transactions: 1/3');
+    });
+  });
+
   describe('handler - edge cases', () => {
     it('should handle empty transaction list', async () => {
       mockFetch.mockResolvedValue([]);

--- a/src/tools/get-transactions/index.ts
+++ b/src/tools/get-transactions/index.ts
@@ -19,8 +19,18 @@ export const schema = {
 export async function handler(args: GetTransactionsArgs): Promise<CallToolResult> {
   try {
     const input = new GetTransactionsInputParser().parse(args);
-    const { accountId, startDate, endDate, minAmount, maxAmount, categoryName, payeeName, uncategorizedOnly, limit } =
-      input;
+    const {
+      accountId,
+      startDate,
+      endDate,
+      minAmount,
+      maxAmount,
+      categoryName,
+      payeeName,
+      uncategorizedOnly,
+      excludeTransfers,
+      limit,
+    } = input;
     const { startDate: start, endDate: end } = getDateRange(startDate, endDate);
 
     // Fetch transactions
@@ -43,6 +53,8 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
     }
     if (uncategorizedOnly) {
       filtered = filtered.filter((t) => !t.category && !t.category_name && !t.transfer_id);
+    } else if (excludeTransfers) {
+      filtered = filtered.filter((t) => !t.transfer_id);
     }
     if (limit && filtered.length > limit) {
       filtered = filtered.slice(0, limit);
@@ -59,6 +71,7 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
       categoryName ? `Category: ${categoryName}` : null,
       payeeName ? `Payee: ${payeeName}` : null,
       uncategorizedOnly ? 'Uncategorized only' : null,
+      !uncategorizedOnly && excludeTransfers ? 'Excluding transfers' : null,
     ]
       .filter(Boolean)
       .join(', ');

--- a/src/tools/get-transactions/input-parser.test.ts
+++ b/src/tools/get-transactions/input-parser.test.ts
@@ -13,4 +13,10 @@ describe(GetTransactionsInputParser.name, () => {
     expect(() => parser.parse(null)).toThrow('Arguments must be an object');
     expect(() => parser.parse('string')).toThrow('Arguments must be an object');
   });
+
+  it('should parse excludeTransfers only when it is a boolean', () => {
+    expect(parser.parse({ excludeTransfers: true }).excludeTransfers).toBe(true);
+    expect(parser.parse({ excludeTransfers: 'true' }).excludeTransfers).toBeUndefined();
+    expect(parser.parse({}).excludeTransfers).toBeUndefined();
+  });
 });

--- a/src/tools/get-transactions/input-parser.ts
+++ b/src/tools/get-transactions/input-parser.ts
@@ -8,8 +8,18 @@ export class GetTransactionsInputParser {
       throw new Error('Arguments must be an object');
     }
     const argsObj = args as Record<string, unknown>;
-    const { accountId, startDate, endDate, minAmount, maxAmount, categoryName, payeeName, uncategorizedOnly, limit } =
-      argsObj;
+    const {
+      accountId,
+      startDate,
+      endDate,
+      minAmount,
+      maxAmount,
+      categoryName,
+      payeeName,
+      uncategorizedOnly,
+      excludeTransfers,
+      limit,
+    } = argsObj;
 
     return {
       accountId: typeof accountId === 'string' && accountId.length > 0 ? accountId : undefined,
@@ -20,6 +30,7 @@ export class GetTransactionsInputParser {
       categoryName: typeof categoryName === 'string' ? categoryName : undefined,
       payeeName: typeof payeeName === 'string' ? payeeName : undefined,
       uncategorizedOnly: typeof uncategorizedOnly === 'boolean' ? uncategorizedOnly : undefined,
+      excludeTransfers: typeof excludeTransfers === 'boolean' ? excludeTransfers : undefined,
       limit: typeof limit === 'number' ? limit : undefined,
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,12 @@ export const GetTransactionsArgsSchema = z.object({
     .boolean()
     .optional()
     .describe('If true, return only transactions that lack a category. Transfers are excluded.'),
+  excludeTransfers: z
+    .boolean()
+    .optional()
+    .describe(
+      'If true, exclude transfers (transactions linked to another account) from the results. Has no additional effect when uncategorizedOnly is true, since transfers are already excluded in that case.'
+    ),
   limit: z.number().optional(),
 });
 


### PR DESCRIPTION
Adds an `excludeTransfers` boolean input to get-transactions that filters
out transfers (transactions with a transfer_id) independently of
`uncategorizedOnly`. Previously transfers were only dropped inside the
`uncategorizedOnly` branch, leaving no clean way to exclude them from a
general (categorized + uncategorized) fetch.

When `uncategorizedOnly` is true, transfers are already excluded, so the
new filter applies only via the `else if` branch to avoid redundant work.

Closes #39

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EpfgHoG8LgbvnNPVvMghWp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `excludeTransfers` boolean parameter to get-transactions queries, allowing users to filter out transfer transactions from results while preserving categorized and uncategorized spend transactions.

* **Tests**
  * Comprehensive test coverage added for the new transfer exclusion option, including parameter validation and behavior verification across different filtering configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->