### PR TITLE
feat: add end-to-end test suite with local budget support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,110 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly run to catch drift against @actual-app/api's bundled budget engine.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      ACTUAL_DATA_DIR: ${{ github.workspace }}/.actual-e2e
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build MCP server
+        run: npm run build
+
+      # Actual's budget engine is in-process, so there is no server to run:
+      # provision a local budget file that both passes below will load.
+      - name: Provision a local budget
+        run: npx tsx e2e/setup-budget.ts
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image for E2E
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: actual-mcp:e2e
+          cache-from: type=gha,scope=actual-mcp-docker
+          cache-to: type=gha,scope=actual-mcp-docker,mode=max
+
+      # ---- CLI build ----
+
+      - name: Start MCP server (CLI build)
+        run: |
+          node build/index.js --sse --enable-write --port 3001 &
+          echo "MCP_CLI_PID=$!" >> "$GITHUB_ENV"
+          for i in $(seq 1 20); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/mcp || true)
+            if [ "$code" = "400" ]; then echo "MCP server (CLI) ready"; exit 0; fi
+            sleep 1
+          done
+          echo "MCP server (CLI) failed to start"
+          exit 1
+
+      - name: Run E2E tests (CLI build)
+        run: npm run test:e2e
+        env:
+          MCP_URL: http://localhost:3001/mcp
+
+      - name: Stop CLI MCP
+        if: always()
+        run: kill "$MCP_CLI_PID" 2>/dev/null || true
+
+      # ---- Docker image ----
+
+      - name: Start MCP server (Docker image)
+        if: ${{ !cancelled() }}
+        run: |
+          docker run -d --name actual-mcp-e2e \
+            --network host \
+            -e ACTUAL_DATA_DIR=/data \
+            -v "$ACTUAL_DATA_DIR":/data \
+            actual-mcp:e2e --sse --enable-write --port 3000
+          for i in $(seq 1 20); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/mcp || true)
+            if [ "$code" = "400" ]; then echo "MCP server (Docker) ready"; exit 0; fi
+            sleep 1
+          done
+          echo "MCP server (Docker) failed to start"
+          docker logs actual-mcp-e2e
+          exit 1
+
+      - name: Run E2E tests (Docker image)
+        if: ${{ !cancelled() }}
+        run: npm run test:e2e
+        env:
+          MCP_URL: http://localhost:3000/mcp
+
+      - name: Print Docker logs on failure
+        if: failure()
+        run: docker logs actual-mcp-e2e --tail=80 || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kill "$MCP_CLI_PID" 2>/dev/null || true
+          docker rm -f actual-mcp-e2e 2>/dev/null || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,11 +13,15 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     env:
       ACTUAL_DATA_DIR: ${{ github.workspace }}/.actual-e2e
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -58,7 +62,7 @@ jobs:
           node build/index.js --sse --enable-write --port 3001 &
           echo "MCP_CLI_PID=$!" >> "$GITHUB_ENV"
           for i in $(seq 1 20); do
-            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/mcp || true)
+            code=$(curl -s --connect-timeout 3 --max-time 5 -o /dev/null -w "%{http_code}" http://localhost:3001/mcp || true)
             if [ "$code" = "400" ]; then echo "MCP server (CLI) ready"; exit 0; fi
             sleep 1
           done
@@ -85,7 +89,7 @@ jobs:
             -v "$ACTUAL_DATA_DIR":/data \
             actual-mcp:e2e --sse --enable-write --port 3000
           for i in $(seq 1 20); do
-            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/mcp || true)
+            code=$(curl -s --connect-timeout 3 --max-time 5 -o /dev/null -w "%{http_code}" http://localhost:3000/mcp || true)
             if [ "$code" = "400" ]; then echo "MCP server (Docker) ready"; exit 0; fi
             sleep 1
           done

--- a/README.md
+++ b/README.md
@@ -330,6 +330,24 @@ To verify the server can connect to your Actual Budget data:
 node build/index.js --test-resources
 ```
 
+### End-to-end tests
+
+The e2e suite drives the running MCP server through a real MCP client. Because
+Actual's budget engine runs in-process via `@actual-app/api`, **no Actual sync
+server is needed** — a local budget file is provisioned on disk and loaded
+directly. To run it locally:
+
+```bash
+npm run build
+export ACTUAL_DATA_DIR="$(mktemp -d)"        # shared by the script and server
+npx tsx e2e/setup-budget.ts                  # create a local budget to load
+node build/index.js --sse --enable-write --port 3001 &
+MCP_URL=http://localhost:3001/mcp npm run test:e2e
+```
+
+CI (`.github/workflows/e2e.yml`) runs the same scenario against both the built
+server and the Docker image.
+
 ### Debugging
 
 Since MCP servers communicate over stdio, debugging can be challenging. You can use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):

--- a/e2e/client.ts
+++ b/e2e/client.ts
@@ -1,0 +1,29 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+export interface ToolResult {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}
+
+export async function connectMcpClient(mcpUrl: string): Promise<Client> {
+  const transport = new StreamableHTTPClientTransport(new URL(mcpUrl));
+  const client = new Client({ name: 'actual-mcp-e2e', version: '1.0.0' }, {});
+  await client.connect(transport);
+  return client;
+}
+
+export function toolText(result: ToolResult): string {
+  const text = result.content.find((c) => c.type === 'text')?.text;
+  if (result.isError) {
+    throw new Error(`Tool returned isError=true: ${text ?? '(no message)'}`);
+  }
+  if (!text) {
+    throw new Error('Tool result had no text content');
+  }
+  return text;
+}
+
+export function toolJson<T>(result: ToolResult): T {
+  return JSON.parse(toolText(result)) as T;
+}

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -1,0 +1,1 @@
+export const ACCOUNT_NAME = 'E2E Checking';

--- a/e2e/scenario.test.ts
+++ b/e2e/scenario.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { connectMcpClient, toolJson, toolText, type ToolResult } from './client';
+import { ACCOUNT_NAME } from './constants';
+
+const MCP_URL = process.env.MCP_URL ?? 'http://localhost:3001/mcp';
+
+// Unique per run: the CLI and Docker passes share one budget, so a fresh payee
+// each run keeps their transactions from colliding.
+const PAYEE = `E2E Coffee ${Date.now()}`;
+const AMOUNT = -1234;
+const TODAY = new Date().toISOString().slice(0, 10);
+
+interface AccountRow {
+  id: string;
+  name: string;
+}
+
+const story: { client?: Client; accountId?: string } = {};
+
+beforeAll(async () => {
+  story.client = await connectMcpClient(MCP_URL);
+});
+
+afterAll(async () => {
+  await story.client?.close?.();
+});
+
+function call(name: string, args: Record<string, unknown>): Promise<ToolResult> {
+  return story.client!.callTool({ name, arguments: args }) as Promise<ToolResult>;
+}
+
+describe('Actual MCP e2e: one transaction from creation to the ledger', () => {
+  it('finds the account that was provisioned for this run', async () => {
+    const accounts = toolJson<AccountRow[]>(await call('get-accounts', {}));
+    const account = accounts.find((a) => a.name === ACCOUNT_NAME);
+    expect(account, `expected a "${ACCOUNT_NAME}" account, got ${JSON.stringify(accounts)}`).toBeTruthy();
+    story.accountId = account!.id;
+  });
+
+  it('records a new transaction against that account', async () => {
+    expect(story.accountId).toBeTruthy();
+    const text = toolText(
+      await call('create-transaction', {
+        account: story.accountId,
+        date: TODAY,
+        amount: AMOUNT,
+        payee_name: PAYEE,
+      })
+    );
+    expect(text).toContain('Successfully created transaction');
+  });
+
+  it('reads that transaction back out of the ledger', async () => {
+    expect(story.accountId).toBeTruthy();
+    const report = toolText(
+      await call('get-transactions', {
+        accountId: story.accountId,
+        startDate: '2000-01-01',
+        endDate: '2999-12-31',
+        payeeName: PAYEE,
+      })
+    );
+    expect(report).toContain(PAYEE);
+    expect(report).toContain('Matching Transactions: 1/');
+  });
+});

--- a/e2e/setup-budget.ts
+++ b/e2e/setup-budget.ts
@@ -1,0 +1,30 @@
+import api from '@actual-app/api';
+import fs from 'node:fs';
+import { ACCOUNT_NAME } from './constants';
+
+async function main(): Promise<void> {
+  const dataDir = process.env.ACTUAL_DATA_DIR;
+  if (!dataDir) {
+    throw new Error('ACTUAL_DATA_DIR must be set so this script and the MCP server share one budget');
+  }
+  fs.mkdirSync(dataDir, { recursive: true });
+
+  // No serverURL: @actual-app/api embeds the budget engine and runs fully local
+  // against dataDir, so the e2e needs no Actual sync server. runImport creates
+  // the very budget the MCP server will pick up via getBudgets() on first use.
+  await api.init({ dataDir });
+  await api.runImport('e2e-budget', async () => {
+    await api.createAccount({ name: ACCOUNT_NAME }, 0);
+  });
+
+  const budgets = await api.getBudgets();
+  console.log(`Provisioned ${budgets.length} budget(s) in ${dataDir}:`);
+  console.log(JSON.stringify(budgets, null, 2));
+
+  await api.shutdown();
+}
+
+main().catch((err) => {
+  console.error('Budget provisioning failed:', err);
+  process.exit(1);
+});

--- a/e2e/setup-budget.ts
+++ b/e2e/setup-budget.ts
@@ -7,6 +7,10 @@ async function main(): Promise<void> {
   if (!dataDir) {
     throw new Error('ACTUAL_DATA_DIR must be set so this script and the MCP server share one budget');
   }
+  // runImport creates a new budget file every run; wipe any prior state so a
+  // reused ACTUAL_DATA_DIR can't leave stale budgets that make budgets[0]
+  // (and therefore the budget the server loads) non-deterministic.
+  fs.rmSync(dataDir, { recursive: true, force: true });
   fs.mkdirSync(dataDir, { recursive: true });
 
   // No serverURL: @actual-app/api embeds the budget engine and runs fully local

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -7,7 +7,7 @@ import globals from 'globals';
 export default tseslint.config(
   // Global ignores
   {
-    ignores: ['node_modules', 'dist', 'build', 'coverage', '**/*.d.ts', 'eslint.config.*'],
+    ignores: ['node_modules', 'dist', 'build', 'coverage', 'e2e', '**/*.d.ts', 'eslint.config.*'],
   },
 
   // Base configurations

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "npm run test:unit",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
+    "test:e2e": "vitest run -c vitest.e2e.config.ts",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint .",

--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -272,6 +272,18 @@ describe('actual-api budget load mode (local vs server)', () => {
     expect(mockApi.downloadBudget).not.toHaveBeenCalled();
   });
 
+  it('prefers the local id over cloudFileId in local mode (edge case)', async () => {
+    // A previously-synced budget has both; loadBudget needs the local id, not
+    // the cloud sync id, so cloudFileId must not win here.
+    mockApi.getBudgets.mockResolvedValue([{ id: 'local-only', cloudFileId: 'cloud-1' }]);
+    const { initActualApi } = await loadModule();
+
+    await initActualApi();
+
+    expect(mockApi.loadBudget).toHaveBeenCalledWith('local-only');
+    expect(mockApi.downloadBudget).not.toHaveBeenCalled();
+  });
+
   it('honors ACTUAL_BUDGET_SYNC_ID over the discovered id in local mode (edge case)', async () => {
     mockApi.getBudgets.mockResolvedValue([{ id: 'local-only' }]);
     process.env.ACTUAL_BUDGET_SYNC_ID = 'pinned-budget';

--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -5,6 +5,7 @@ const mockApi = {
   init: vi.fn(),
   getBudgets: vi.fn(),
   downloadBudget: vi.fn(),
+  loadBudget: vi.fn(),
   shutdown: vi.fn(),
   sync: vi.fn(),
 };
@@ -37,9 +38,12 @@ describe('actual-api init/shutdown stability (#96)', () => {
     mockApi.getBudgets.mockResolvedValue([{ id: 'budget-1', cloudFileId: 'budget-1' }]);
     mockApi.init.mockResolvedValue(undefined);
     mockApi.downloadBudget.mockResolvedValue(undefined);
+    mockApi.loadBudget.mockResolvedValue(undefined);
     mockApi.shutdown.mockResolvedValue(undefined);
     mockApi.sync.mockResolvedValue(undefined);
     delete process.env.ACTUAL_MCP_CACHE_TTL_SECONDS;
+    // These suites exercise the server path; the load-mode branch is covered separately.
+    process.env.ACTUAL_SERVER_URL = 'https://actual.example.test';
   });
 
   afterEach(() => {
@@ -140,9 +144,12 @@ describe('actual-api budget caching', () => {
     mockApi.getBudgets.mockResolvedValue([{ id: 'budget-1', cloudFileId: 'budget-1' }]);
     mockApi.init.mockResolvedValue(undefined);
     mockApi.downloadBudget.mockResolvedValue(undefined);
+    mockApi.loadBudget.mockResolvedValue(undefined);
     mockApi.shutdown.mockResolvedValue(undefined);
     mockApi.sync.mockResolvedValue(undefined);
     delete process.env.ACTUAL_MCP_CACHE_TTL_SECONDS;
+    // These suites exercise the server path; the load-mode branch is covered separately.
+    process.env.ACTUAL_SERVER_URL = 'https://actual.example.test';
   });
 
   afterEach(() => {
@@ -223,5 +230,55 @@ describe('actual-api budget caching', () => {
 
     expect(mockApi.shutdown).toHaveBeenCalledTimes(1);
     expect(mockApi.init).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('actual-api budget load mode (local vs server)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.getBudgets.mockResolvedValue([{ id: 'budget-1', cloudFileId: 'cloud-1' }]);
+    mockApi.init.mockResolvedValue(undefined);
+    mockApi.downloadBudget.mockResolvedValue(undefined);
+    mockApi.loadBudget.mockResolvedValue(undefined);
+    mockApi.shutdown.mockResolvedValue(undefined);
+    delete process.env.ACTUAL_MCP_CACHE_TTL_SECONDS;
+    delete process.env.ACTUAL_SERVER_URL;
+    delete process.env.ACTUAL_BUDGET_SYNC_ID;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.ACTUAL_SERVER_URL;
+    delete process.env.ACTUAL_BUDGET_SYNC_ID;
+  });
+
+  it('downloads from the server when ACTUAL_SERVER_URL is set (happy path)', async () => {
+    process.env.ACTUAL_SERVER_URL = 'https://actual.example.test';
+    const { initActualApi } = await loadModule();
+
+    await initActualApi();
+
+    expect(mockApi.downloadBudget).toHaveBeenCalledWith('cloud-1', undefined);
+    expect(mockApi.loadBudget).not.toHaveBeenCalled();
+  });
+
+  it('loads the on-disk budget directly in local-only mode (no server)', async () => {
+    mockApi.getBudgets.mockResolvedValue([{ id: 'local-only' }]);
+    const { initActualApi } = await loadModule();
+
+    await initActualApi();
+
+    expect(mockApi.loadBudget).toHaveBeenCalledWith('local-only');
+    expect(mockApi.downloadBudget).not.toHaveBeenCalled();
+  });
+
+  it('honors ACTUAL_BUDGET_SYNC_ID over the discovered id in local mode (edge case)', async () => {
+    mockApi.getBudgets.mockResolvedValue([{ id: 'local-only' }]);
+    process.env.ACTUAL_BUDGET_SYNC_ID = 'pinned-budget';
+    const { initActualApi } = await loadModule();
+
+    await initActualApi();
+
+    expect(mockApi.loadBudget).toHaveBeenCalledWith('pinned-budget');
   });
 });

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -70,14 +70,22 @@ async function loadBudget(): Promise<void> {
 
   const budgetId: string = process.env.ACTUAL_BUDGET_SYNC_ID || budgets[0].cloudFileId || budgets[0].id || '';
   console.error(`Loading budget: ${budgetId}`);
-  await api.downloadBudget(
-    budgetId,
-    process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD
-      ? {
-          password: process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD,
-        }
-      : undefined
-  );
+  if (process.env.ACTUAL_SERVER_URL) {
+    await api.downloadBudget(
+      budgetId,
+      process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD
+        ? {
+            password: process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD,
+          }
+        : undefined
+    );
+  } else {
+    // Reason: downloadBudget always asks a sync server for the remote file list
+    // and throws "Could not get remote files" when none is configured. In
+    // local-only mode (ACTUAL_DATA_DIR without ACTUAL_SERVER_URL) the budget is
+    // already on disk, so load it directly instead of trying to download it.
+    await api.loadBudget(budgetId);
+  }
 
   console.error('Actual Budget API initialized successfully');
 }
@@ -132,6 +140,9 @@ export function scheduleShutdown(): Promise<void> | void {
 
 export async function syncBudget(): Promise<void> {
   if (!initPromise) return;
+  // Reason: api.sync() reconciles with a sync server; in local-only mode
+  // (no ACTUAL_SERVER_URL) there is no server and the call errors out.
+  if (!process.env.ACTUAL_SERVER_URL) return;
   try {
     await api.sync();
   } catch (err) {

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -68,11 +68,11 @@ async function loadBudget(): Promise<void> {
     throw new Error('No budgets found. Please create a budget in Actual first.');
   }
 
-  const budgetId: string = process.env.ACTUAL_BUDGET_SYNC_ID || budgets[0].cloudFileId || budgets[0].id || '';
-  console.error(`Loading budget: ${budgetId}`);
   if (process.env.ACTUAL_SERVER_URL) {
+    const syncId: string = process.env.ACTUAL_BUDGET_SYNC_ID || budgets[0].cloudFileId || budgets[0].id || '';
+    console.error(`Downloading budget: ${syncId}`);
     await api.downloadBudget(
-      budgetId,
+      syncId,
       process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD
         ? {
             password: process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD,
@@ -83,8 +83,11 @@ async function loadBudget(): Promise<void> {
     // Reason: downloadBudget always asks a sync server for the remote file list
     // and throws "Could not get remote files" when none is configured. In
     // local-only mode (ACTUAL_DATA_DIR without ACTUAL_SERVER_URL) the budget is
-    // already on disk, so load it directly instead of trying to download it.
-    await api.loadBudget(budgetId);
+    // already on disk, so load it directly. loadBudget takes the local budget
+    // id (not the cloud sync id), so prefer id over cloudFileId here.
+    const localId: string = process.env.ACTUAL_BUDGET_SYNC_ID || budgets[0].id || budgets[0].cloudFileId || '';
+    console.error(`Loading local budget: ${localId}`);
+    await api.loadBudget(localId);
   }
 
   console.error('Actual Budget API initialized successfully');

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    include: ['e2e/**/*.test.ts'],
+    globals: true,
+    testTimeout: 60000,
+    hookTimeout: 60000,
+  },
+});


### PR DESCRIPTION
## Summary

This PR adds a comprehensive end-to-end test suite that validates the MCP server against a real Actual Budget instance running locally. It also introduces support for local-only budget mode (without a sync server), enabling the e2e tests to run without external dependencies.

## Key Changes

- **E2E Test Infrastructure** (`e2e/` directory):
  - `scenario.test.ts`: Main e2e test suite that exercises the full transaction lifecycle (create, read, verify)
  - `client.ts`: MCP client connection and result parsing utilities
  - `setup-budget.ts`: Budget provisioning script that creates a local budget file
  - `constants.ts`: Shared test constants

- **Local Budget Mode Support** (`src/actual-api.ts`):
  - Added conditional logic to use `api.loadBudget()` when `ACTUAL_SERVER_URL` is not set
  - Updated `syncBudget()` to skip sync operations in local-only mode
  - Preserves existing server-based workflow when `ACTUAL_SERVER_URL` is configured

- **CI/CD Pipeline** (`.github/workflows/e2e.yml`):
  - Automated e2e test execution on push to main, pull requests, and weekly schedule
  - Tests both CLI build and Docker image deployments
  - Provisions a shared local budget that both test passes use
  - Includes health checks and comprehensive logging

- **Test Configuration**:
  - `vitest.e2e.config.ts`: Separate Vitest config for e2e tests with extended timeouts
  - `package.json`: Added `test:e2e` npm script

- **Unit Test Updates** (`src/actual-api.test.ts`):
  - Added mock for `loadBudget` API method
  - New test suite covering local vs. server budget loading modes
  - Tests verify correct API calls based on environment configuration

- **Documentation** (`README.md`):
  - Added e2e testing section with local setup instructions
  - Explains the local-only budget mode and CI workflow

## Implementation Details

The e2e tests leverage Actual's in-process budget engine (`@actual-app/api`) which eliminates the need for an external sync server. A local budget file is provisioned once and shared between the setup script and the running MCP server. The test suite validates:
- Account discovery via `get-accounts` tool
- Transaction creation via `create-transaction` tool
- Transaction retrieval via `get-transactions` tool

The local budget mode is backward compatible—when `ACTUAL_SERVER_URL` is set, the server-based workflow is used; when absent, the budget is loaded directly from disk.

https://claude.ai/code/session_01C9uMGmku1y284pCrpwjV2u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end test coverage that runs against both a local server and a Docker-based server.
  * Introduced a dedicated E2E test command and configuration.

* **Bug Fixes**
  * Improved budget loading so local setups work without a remote server.
  * Prevented sync attempts when no server is configured.

* **Documentation**
  * Added setup and usage instructions for running end-to-end tests locally and in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->